### PR TITLE
Adapt to new node identifiers (TEDEFO-923)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
             <artifactItem>
               <groupId>eu.europa.ted.eforms</groupId>
               <artifactId>eforms-sdk</artifactId>
-              <version>0.6.0</version>
+              <version>0.6.1-SNAPSHOT</version>
               <type>jar</type>
               <includes>eforms-sdk/efx-grammar/**/*.g4</includes>
               <outputDirectory>${sdk.antlr4.dir}/eu/europa/ted/efx/sdk0/v6</outputDirectory>

--- a/src/test/java/eu/europa/ted/efx/EfxExpressionCombinedTest.java
+++ b/src/test/java/eu/europa/ted/efx/EfxExpressionCombinedTest.java
@@ -24,13 +24,13 @@ public class EfxExpressionCombinedTest {
     @Test
     public void testNotPresentAndNotPresent() {
         assertEquals("not(PathNode/TextField) and not(PathNode/IntegerField)",
-                test("ND-0", "BT-00-Text is not present and BT-00-Integer is not present"));
+                test("ND-Root", "BT-00-Text is not present and BT-00-Integer is not present"));
     }
 
     @Test
     public void testCountWithNodeContextOverride() {
         assertEquals("count(../../PathNode/CodeField) = 1",
-                test("BT-00-Text", "count(ND-0::BT-00-Code) == 1"));
+                test("BT-00-Text", "count(ND-Root::BT-00-Code) == 1"));
     }
 
     @Test

--- a/src/test/java/eu/europa/ted/efx/EfxExpressionTranslatorTest.java
+++ b/src/test/java/eu/europa/ted/efx/EfxExpressionTranslatorTest.java
@@ -40,25 +40,25 @@ public class EfxExpressionTranslatorTest {
     @Test
     public void testEmptinessCondition() {
         assertEquals("PathNode/TextField/normalize-space(text()) = ''",
-                test("ND-0", "BT-00-Text is empty"));
+                test("ND-Root", "BT-00-Text is empty"));
     }
 
     @Test
     public void testEmptinessCondition_WithNot() {
         assertEquals("PathNode/TextField/normalize-space(text()) != ''",
-                test("ND-0", "BT-00-Text is not empty"));
+                test("ND-Root", "BT-00-Text is not empty"));
     }
 
     @Test
     public void testPresenceCondition() {
         assertEquals("PathNode/TextField",
-                test("ND-0", "BT-00-Text is present"));
+                test("ND-Root", "BT-00-Text is present"));
     }
 
     @Test
     public void testPresenceCondition_WithNot() {
         assertEquals("not(PathNode/TextField)",
-                test("ND-0", "BT-00-Text is not present"));
+                test("ND-Root", "BT-00-Text is not present"));
     }
 
     @Test
@@ -76,13 +76,13 @@ public class EfxExpressionTranslatorTest {
     @Test
     public void testFieldValueComparison() {
         assertEquals("PathNode/TextField/normalize-space(text()) = PathNode/TextMultilingualField/normalize-space(text())",
-                test("ND-0", "BT-00-Text == BT-00-Text-Multilingual"));
+                test("ND-Root", "BT-00-Text == BT-00-Text-Multilingual"));
     }
 
     @Test
     public void testFieldValueComparison_WithNumericLiteral() {
         assertEquals("PathNode/IntegerField/number() > 0",
-                test("ND-0", "BT-00-Integer > 0"));
+                test("ND-Root", "BT-00-Integer > 0"));
     }
 
     @Test
@@ -112,13 +112,13 @@ public class EfxExpressionTranslatorTest {
     @Test
     public void testDateComparison_OfTwoDateReferences() {
         assertEquals("PathNode/StartDateField/xs:date(text()) = PathNode/EndDateField/xs:date(text())",
-                test("ND-0", "BT-00-StartDate == BT-00-EndDate"));
+                test("ND-Root", "BT-00-StartDate == BT-00-EndDate"));
     }
 
     @Test
     public void testDateComparison_OfDateReferenceAndDateFunction() {
         assertEquals("PathNode/StartDateField/xs:date(text()) = xs:date(PathNode/TextField/normalize-space(text()))",
-                test("ND-0", "BT-00-StartDate == date(BT-00-Text)"));
+                test("ND-Root", "BT-00-StartDate == date(BT-00-Text)"));
     }
     
     @Test
@@ -130,13 +130,13 @@ public class EfxExpressionTranslatorTest {
     @Test
     public void testTimeComparison_OfTwoTimeReferences() {
         assertEquals("PathNode/StartTimeField/xs:time(text()) = PathNode/EndTimeField/xs:time(text())",
-                test("ND-0", "BT-00-StartTime == BT-00-EndTime"));
+                test("ND-Root", "BT-00-StartTime == BT-00-EndTime"));
     }
 
     @Test
     public void testTimeComparison_OfTimeReferenceAndTimeFunction() {
         assertEquals("PathNode/StartTimeField/xs:time(text()) = xs:time(PathNode/TextField/normalize-space(text()))",
-                test("ND-0", "BT-00-StartTime == time(BT-00-Text)"));
+                test("ND-Root", "BT-00-StartTime == time(BT-00-Text)"));
     }
 
     @Test
@@ -154,38 +154,38 @@ public class EfxExpressionTranslatorTest {
     @Test
     public void testCalculatedDurationComparison() {
         assertEquals("boolean(for $T in (current-date()) return ($T + xs:yearMonthDuration('P3M') > $T + xs:dayTimeDuration(PathNode/EndDateField/xs:date(text()) - PathNode/StartDateField/xs:date(text()))))",
-                test("ND-0", "P3M > (BT-00-EndDate - BT-00-StartDate)"));
+                test("ND-Root", "P3M > (BT-00-EndDate - BT-00-StartDate)"));
     }
 
     
     @Test
     public void testNegativeDuration_Literal() {
         assertEquals("xs:yearMonthDuration('-P3M')",
-                test("ND-0", "-P3M"));
+                test("ND-Root", "-P3M"));
     }
 
     @Test
     public void testNegativeDuration_ViaMultiplication() {
         assertEquals("(-3 * (2 * xs:yearMonthDuration('-P3M')))",
-                test("ND-0", "2 * -P3M * -3"));
+                test("ND-Root", "2 * -P3M * -3"));
     }
 
     @Test
     public void testNegativeDuration_ViaMultiplicationWithField() {
         assertEquals("(-3 * (2 * (if (lower-case(PathNode/MeasureField/@unit)='w') then xs:dayTimeDuration(concat('P', PathNode/MeasureField/number() * 7, 'D')) else if (lower-case(PathNode/MeasureField/@unit)='d') then xs:dayTimeDuration(concat('P', PathNode/MeasureField/number(), upper-case(PathNode/MeasureField/@unit))) else xs:yearMonthDuration(concat('P', PathNode/MeasureField/number(), upper-case(PathNode/MeasureField/@unit))))))",
-                test("ND-0", "2 * measure:BT-00-Measure * -3"));
+                test("ND-Root", "2 * measure:BT-00-Measure * -3"));
     }
 
     @Test
     public void testDurationAddition() {
         assertEquals("(xs:dayTimeDuration('P3D') + xs:dayTimeDuration(PathNode/StartDateField/xs:date(text()) - PathNode/EndDateField/xs:date(text())))",
-                test("ND-0", "P3D + (BT-00-StartDate - BT-00-EndDate)"));
+                test("ND-Root", "P3D + (BT-00-StartDate - BT-00-EndDate)"));
     }
 
     @Test
     public void testDurationSubtraction() {
         assertEquals("(xs:dayTimeDuration('P3D') - xs:dayTimeDuration(PathNode/StartDateField/xs:date(text()) - PathNode/EndDateField/xs:date(text())))",
-                test("ND-0", "P3D - (BT-00-StartDate - BT-00-EndDate)"));
+                test("ND-Root", "P3D - (BT-00-StartDate - BT-00-EndDate)"));
     }
 
     @Test
@@ -240,31 +240,31 @@ public class EfxExpressionTranslatorTest {
     @Test
     public void testFieldAttributeValueReference() {
         assertEquals("PathNode/TextField/@Attribute = 'text'",
-                test("ND-0", "BT-00-Attribute == 'text'"));
+                test("ND-Root", "BT-00-Attribute == 'text'"));
     }
 
     @Test
     public void testUntypedAttributeValueReference() {
         assertEquals("PathNode/CodeField/@listName",
-                test("ND-0", "BT-00-Code/@listName"));
+                test("ND-Root", "BT-00-Code/@listName"));
     }
 
     @Test
     public void testFieldReferenceWithPredicate() {
         assertEquals("PathNode/IndicatorField['a' = 'a']",
-                test("ND-0", "BT-00-Indicator['a' == 'a']"));
+                test("ND-Root", "BT-00-Indicator['a' == 'a']"));
     }
 
     @Test
     public void testFieldReferenceWithPredicate_WithFieldReferenceInPredicate() {
         assertEquals("PathNode/IndicatorField[../CodeField/normalize-space(text()) = 'a']",
-                test("ND-0", "BT-00-Indicator[BT-00-Code == 'a']"));
+                test("ND-Root", "BT-00-Indicator[BT-00-Code == 'a']"));
     }
 
     @Test
     public void testFieldReferenceInOtherNotice() {
         assertEquals("fn:doc(concat('http://notice.service/', 'da4d46e9-490b-41ff-a2ae-8166d356a619')')/PathNode/TextField/normalize-space(text())",
-                test("ND-0", "notice('da4d46e9-490b-41ff-a2ae-8166d356a619')/BT-00-Text"));
+                test("ND-Root", "notice('da4d46e9-490b-41ff-a2ae-8166d356a619')/BT-00-Text"));
     }
 
     @Test
@@ -282,13 +282,13 @@ public class EfxExpressionTranslatorTest {
     @Test
     public void testFieldReferenceWithNodeContextOverride() {
         assertEquals("../../PathNode/IntegerField/number()",
-                test("BT-00-Text", "ND-0::BT-00-Integer"));
+                test("BT-00-Text", "ND-Root::BT-00-Integer"));
     }
 
     @Test
     public void testFieldReferenceWithNodeContextOverride_WithPredicate() {
         assertEquals("../../PathNode/IntegerField/number()",
-                test("BT-00-Text", "ND-0[BT-00-Indicator == TRUE]::BT-00-Integer"));
+                test("BT-00-Text", "ND-Root[BT-00-Indicator == TRUE]::BT-00-Integer"));
     }
 
     @Test
@@ -306,7 +306,7 @@ public class EfxExpressionTranslatorTest {
     @Test
     public void testFieldReference_ForDurationFields() {
         assertEquals("(if (lower-case(PathNode/MeasureField/@unit)='w') then xs:dayTimeDuration(concat('P', PathNode/MeasureField/number() * 7, 'D')) else if (lower-case(PathNode/MeasureField/@unit)='d') then xs:dayTimeDuration(concat('P', PathNode/MeasureField/number(), upper-case(PathNode/MeasureField/@unit))) else xs:yearMonthDuration(concat('P', PathNode/MeasureField/number(), upper-case(PathNode/MeasureField/@unit))))",
-                test("ND-0", "BT-00-Measure"));
+                test("ND-Root", "BT-00-Measure"));
     } 
 
     /*** Boolean functions ***/
@@ -321,43 +321,43 @@ public class EfxExpressionTranslatorTest {
     @Test
     public void testContainsFunction() {
         assertEquals("contains(PathNode/TextField/normalize-space(text()), 'xyz')",
-                test("ND-0", "contains(BT-00-Text, 'xyz')"));
+                test("ND-Root", "contains(BT-00-Text, 'xyz')"));
     }
 
     @Test
     public void testStartsWithFunction() {
         assertEquals("starts-with(PathNode/TextField/normalize-space(text()), 'abc')",
-                test("ND-0", "starts-with(BT-00-Text, 'abc')"));
+                test("ND-Root", "starts-with(BT-00-Text, 'abc')"));
     }
 
     @Test
     public void testEndsWithFunction() {
         assertEquals("ends-with(PathNode/TextField/normalize-space(text()), 'abc')",
-                test("ND-0", "ends-with(BT-00-Text, 'abc')"));
+                test("ND-Root", "ends-with(BT-00-Text, 'abc')"));
     }
 
     /*** Numeric functions ***/
 
     @Test
     public void testCountFunction() {
-        assertEquals("count(PathNode/TextField)", test("ND-0", "count(BT-00-Text)"));
+        assertEquals("count(PathNode/TextField)", test("ND-Root", "count(BT-00-Text)"));
     }
 
     @Test
     public void testNumberFunction() {
         assertEquals("number(PathNode/TextField/normalize-space(text()))",
-                test("ND-0", "number(BT-00-Text)"));
+                test("ND-Root", "number(BT-00-Text)"));
     }
 
     @Test
     public void testSumFunction() {
-        assertEquals("sum(PathNode/NumberField)", test("ND-0", "sum(BT-00-Number)"));
+        assertEquals("sum(PathNode/NumberField)", test("ND-Root", "sum(BT-00-Number)"));
     }
 
     @Test
     public void testStringLengthFunction() {
         assertEquals("string-length(PathNode/TextField/normalize-space(text()))",
-                test("ND-0", "string-length(BT-00-Text)"));
+                test("ND-Root", "string-length(BT-00-Text)"));
     }
 
     /*** String functions ***/
@@ -365,25 +365,25 @@ public class EfxExpressionTranslatorTest {
     @Test
     public void testSubstringFunction() {
         assertEquals("substring(PathNode/TextField/normalize-space(text()), 1, 3)",
-                test("ND-0", "substring(BT-00-Text, 1, 3)"));
+                test("ND-Root", "substring(BT-00-Text, 1, 3)"));
         assertEquals("substring(PathNode/TextField/normalize-space(text()), 4)",
-                test("ND-0", "substring(BT-00-Text, 4)"));
+                test("ND-Root", "substring(BT-00-Text, 4)"));
     }
 
     @Test
     public void testToStringFunction() {
-        assertEquals("string(123)", test("ND-0", "string(123)"));
+        assertEquals("string(123)", test("ND-Root", "string(123)"));
     }
 
     @Test
     public void testConcatFunction() {
-        assertEquals("concat('abc', 'def')", test("ND-0", "concat('abc', 'def')"));
+        assertEquals("concat('abc', 'def')", test("ND-Root", "concat('abc', 'def')"));
     };
 
     @Test
     public void testFormatNumberFunction() {
         assertEquals("format-number(PathNode/NumberField/number(), '#,##0.00')",
-                test("ND-0", "format-number(BT-00-Number, '#,##0.00')"));
+                test("ND-Root", "format-number(BT-00-Number, '#,##0.00')"));
     }
 
 
@@ -392,7 +392,7 @@ public class EfxExpressionTranslatorTest {
     @Test
     public void testDateFromStringFunction() {
         assertEquals("xs:date(PathNode/TextField/normalize-space(text()))",
-                test("ND-0", "date(BT-00-Text)"));
+                test("ND-Root", "date(BT-00-Text)"));
     }
 
     /*** Time functions ***/
@@ -400,6 +400,6 @@ public class EfxExpressionTranslatorTest {
     @Test
     public void testTimeFromStringFunction() {
         assertEquals("xs:time(PathNode/TextField/normalize-space(text()))",
-                test("ND-0", "time(BT-00-Text)"));
+                test("ND-Root", "time(BT-00-Text)"));
     }
 }

--- a/src/test/java/eu/europa/ted/efx/EfxTemplateTranslatorTest.java
+++ b/src/test/java/eu/europa/ted/efx/EfxTemplateTranslatorTest.java
@@ -199,8 +199,8 @@ public class EfxTemplateTranslatorTest {
     public void testShorthandContextLabelReference_WithNodeContext() {
         // TODO: Check if Node -> business_term is intended
         assertEquals(
-                "block01 = label(concat('business_term', '|', 'name', '|', 'ND-0')); for-each(/*) { block01(); }",
-                translate("{ND-0}  #{name}"));
+                "block01 = label(concat('business_term', '|', 'name', '|', 'ND-Root')); for-each(/*) { block01(); }",
+                translate("{ND-Root}  #{name}"));
     }
 
     @Test
@@ -213,7 +213,7 @@ public class EfxTemplateTranslatorTest {
     @Test
     public void testShorthandContextFieldLabelReference_WithNodeContext() {
         assertThrows(ParseCancellationException.class,
-                () -> translate("{ND-0} #value"));
+                () -> translate("{ND-Root} #value"));
     }
 
 
@@ -236,7 +236,7 @@ public class EfxTemplateTranslatorTest {
     @Test
     public void testShorthandContextFieldValueReference_WithNodeContext() {
         assertThrows(ParseCancellationException.class,
-                () -> translate("{ND-0} $value"));
+                () -> translate("{ND-Root} $value"));
     }
 
 

--- a/src/test/java/eu/europa/ted/efx/mock/SymbolResolverMock.java
+++ b/src/test/java/eu/europa/ted/efx/mock/SymbolResolverMock.java
@@ -47,49 +47,49 @@ public class SymbolResolverMock implements SymbolResolver {
     public void loadMapData() throws JsonMappingException, JsonProcessingException {
         this.fieldById = Map.ofEntries(//
                 entry("BT-00-Text", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Text\",\"type\":\"text\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/TextField\",\"xpathRelative\":\"PathNode/TextField\"}"))),
+                        "{\"id\":\"BT-00-Text\",\"type\":\"text\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/TextField\",\"xpathRelative\":\"PathNode/TextField\"}"))),
                 entry("BT-00-Attribute", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Attribute\",\"type\":\"text\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/TextField/@Attribute\",\"xpathRelative\":\"PathNode/TextField/@Attribute\"}"))),
+                        "{\"id\":\"BT-00-Attribute\",\"type\":\"text\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/TextField/@Attribute\",\"xpathRelative\":\"PathNode/TextField/@Attribute\"}"))),
                 entry("BT-00-Indicator", new SdkField(fromString(
-                        "{\"id\":\"BT-00-indicator\",\"type\":\"indicator\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/IndicatorField\",\"xpathRelative\":\"PathNode/IndicatorField\"}"))),
+                        "{\"id\":\"BT-00-indicator\",\"type\":\"indicator\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/IndicatorField\",\"xpathRelative\":\"PathNode/IndicatorField\"}"))),
                 entry("BT-00-Code", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Code\",\"type\":\"code\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/CodeField\",\"xpathRelative\":\"PathNode/CodeField\",\"codeList\":{\"value\":{\"id\":\"authority-activity\",\"type\":\"flat\",\"parentId\":\"main-activity\"}}}"))),
+                        "{\"id\":\"BT-00-Code\",\"type\":\"code\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/CodeField\",\"xpathRelative\":\"PathNode/CodeField\",\"codeList\":{\"value\":{\"id\":\"authority-activity\",\"type\":\"flat\",\"parentId\":\"main-activity\"}}}"))),
                 entry("BT-00-Internal-Code", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Internal-Code\",\"type\":\"internal-code\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/InternalCodeField\",\"xpathRelative\":\"PathNode/CodeField\",\"codeList\":{\"value\":{\"id\":\"authority-activity\",\"type\":\"flat\",\"parentId\":\"main-activity\"}}}"))),
+                        "{\"id\":\"BT-00-Internal-Code\",\"type\":\"internal-code\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/InternalCodeField\",\"xpathRelative\":\"PathNode/CodeField\",\"codeList\":{\"value\":{\"id\":\"authority-activity\",\"type\":\"flat\",\"parentId\":\"main-activity\"}}}"))),
                 entry("BT-00-Text-Multilingual", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Text-Multilingual\",\"type\":\"text-multilingual\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/TextMultilingualField\",\"xpathRelative\":\"PathNode/TextMultilingualField\"}}"))),
+                        "{\"id\":\"BT-00-Text-Multilingual\",\"type\":\"text-multilingual\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/TextMultilingualField\",\"xpathRelative\":\"PathNode/TextMultilingualField\"}}"))),
                 entry("BT-00-StartDate", new SdkField(fromString(
-                        "{\"id\":\"BT-00-StartDate\",\"type\":\"date\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/StartDateField\",\"xpathRelative\":\"PathNode/StartDateField\"}}"))),
+                        "{\"id\":\"BT-00-StartDate\",\"type\":\"date\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/StartDateField\",\"xpathRelative\":\"PathNode/StartDateField\"}}"))),
                 entry("BT-00-EndDate", new SdkField(fromString(
-                        "{\"id\":\"BT-00-EndDate\",\"type\":\"date\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/EndDateField\",\"xpathRelative\":\"PathNode/EndDateField\"}}"))),
+                        "{\"id\":\"BT-00-EndDate\",\"type\":\"date\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/EndDateField\",\"xpathRelative\":\"PathNode/EndDateField\"}}"))),
                 entry("BT-00-StartTime", new SdkField(fromString(
-                        "{\"id\":\"BT-00-StartTime\",\"type\":\"time\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/StartTimeField\",\"xpathRelative\":\"PathNode/StartTimeField\"}}"))),
+                        "{\"id\":\"BT-00-StartTime\",\"type\":\"time\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/StartTimeField\",\"xpathRelative\":\"PathNode/StartTimeField\"}}"))),
                 entry("BT-00-EndTime", new SdkField(fromString(
-                        "{\"id\":\"BT-00-EndTime\",\"type\":\"time\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/EndTimeField\",\"xpathRelative\":\"PathNode/EndTimeField\"}}"))),
+                        "{\"id\":\"BT-00-EndTime\",\"type\":\"time\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/EndTimeField\",\"xpathRelative\":\"PathNode/EndTimeField\"}}"))),
                 entry("BT-00-Measure", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Measure\",\"type\":\"measure\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/MeasureField\",\"xpathRelative\":\"PathNode/MeasureField\"}}"))),
+                        "{\"id\":\"BT-00-Measure\",\"type\":\"measure\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/MeasureField\",\"xpathRelative\":\"PathNode/MeasureField\"}}"))),
                 entry("BT-00-Integer", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Integer\",\"type\":\"integer\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/IntegerField\",\"xpathRelative\":\"PathNode/IntegerField\"}}"))),
+                        "{\"id\":\"BT-00-Integer\",\"type\":\"integer\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/IntegerField\",\"xpathRelative\":\"PathNode/IntegerField\"}}"))),
                 entry("BT-00-Amount", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Amount\",\"type\":\"amount\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/AmountField\",\"xpathRelative\":\"PathNode/AmountField\"}}"))),
+                        "{\"id\":\"BT-00-Amount\",\"type\":\"amount\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/AmountField\",\"xpathRelative\":\"PathNode/AmountField\"}}"))),
                 entry("BT-00-Url", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Url\",\"type\":\"url\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/UrlField\",\"xpathRelative\":\"PathNode/UrlField\"}}"))),
+                        "{\"id\":\"BT-00-Url\",\"type\":\"url\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/UrlField\",\"xpathRelative\":\"PathNode/UrlField\"}}"))),
                 entry("BT-00-Zoned-Date", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Zoned-Date\",\"type\":\"zoned-date\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/ZonedDateField\",\"xpathRelative\":\"PathNode/ZonedDateField\"}}"))),
+                        "{\"id\":\"BT-00-Zoned-Date\",\"type\":\"zoned-date\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/ZonedDateField\",\"xpathRelative\":\"PathNode/ZonedDateField\"}}"))),
                 entry("BT-00-Zoned-Time", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Zoned-Time\",\"type\":\"zoned-time\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/ZonedTimeField\",\"xpathRelative\":\"PathNode/ZonedTimeField\"}}"))),
+                        "{\"id\":\"BT-00-Zoned-Time\",\"type\":\"zoned-time\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/ZonedTimeField\",\"xpathRelative\":\"PathNode/ZonedTimeField\"}}"))),
                 entry("BT-00-Id-Ref", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Id-Ref\",\"type\":\"id-ref\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/IdRefField\",\"xpathRelative\":\"PathNode/IdRefField\"}}"))),
+                        "{\"id\":\"BT-00-Id-Ref\",\"type\":\"id-ref\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/IdRefField\",\"xpathRelative\":\"PathNode/IdRefField\"}}"))),
                 entry("BT-00-Number", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Number\",\"type\":\"number\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/NumberField\",\"xpathRelative\":\"PathNode/NumberField\"}}"))),
+                        "{\"id\":\"BT-00-Number\",\"type\":\"number\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/NumberField\",\"xpathRelative\":\"PathNode/NumberField\"}}"))),
                 entry("BT-00-Phone", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Phone\",\"type\":\"phone\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/PhoneField\",\"xpathRelative\":\"PathNode/PhoneField\"}}"))),
+                        "{\"id\":\"BT-00-Phone\",\"type\":\"phone\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/PhoneField\",\"xpathRelative\":\"PathNode/PhoneField\"}}"))),
                 entry("BT-00-Email", new SdkField(fromString(
-                        "{\"id\":\"BT-00-Email\",\"type\":\"email\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/EmailField\",\"xpathRelative\":\"PathNode/EmailField\"}}"))),
+                        "{\"id\":\"BT-00-Email\",\"type\":\"email\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/EmailField\",\"xpathRelative\":\"PathNode/EmailField\"}}"))),
                 entry("BT-01-SubLevel-Text", new SdkField(fromString(
-                        "{\"id\":\"BT-01-SubLevel-Text\",\"type\":\"text\",\"parentNodeId\":\"ND-0\",\"xpathAbsolute\":\"/*/PathNode/ChildNode/SubLevelTextField\",\"xpathRelative\":\"PathNode/ChildNode/SubLevelTextField\"}}"))));
+                        "{\"id\":\"BT-01-SubLevel-Text\",\"type\":\"text\",\"parentNodeId\":\"ND-Root\",\"xpathAbsolute\":\"/*/PathNode/ChildNode/SubLevelTextField\",\"xpathRelative\":\"PathNode/ChildNode/SubLevelTextField\"}}"))));
 
-        this.nodeById = Map.ofEntries(entry("ND-0", new SdkNode("ND-0", null, "/*", "/*", false)));
+        this.nodeById = Map.ofEntries(entry("ND-Root", new SdkNode("ND-Root", null, "/*", "/*", false)));
 
         this.codelistById =
                 new HashMap<>(Map.ofEntries(entry("accessibility", new SdkCodelist("accessibility",


### PR DESCRIPTION
Bump eforms-sdk dependency to 0.6.1-SNAPSHOT, to get the grammar that
accepts the new node identifiers.

Replace "ND-0" with "ND-Root" in all unit tests, to match the real
identifier.

This requires the changes in OP-TED/eforms-sdk#13