### PR TITLE
TEDEFO-1036: fix EfxTemplateTranslator for v7

### DIFF
--- a/src/main/java/eu/europa/ted/efx/EfxTranslator.java
+++ b/src/main/java/eu/europa/ted/efx/EfxTranslator.java
@@ -67,7 +67,7 @@ public class EfxTranslator {
         return eu.europa.ted.efx.sdk0.v6.EfxTemplateTranslator.renderTemplate(stream, factory,
             sdkVersion);
       case SDK_0_7:
-            return eu.europa.ted.efx.sdk0.v6.EfxTemplateTranslator.renderTemplate(stream, factory,
+            return eu.europa.ted.efx.sdk0.v7.EfxTemplateTranslator.renderTemplate(stream, factory,
                 sdkVersion);
           default:
         throw new RuntimeException(String.format(SDK_VERSION_V_NOT_SUPPORTED, sdkVersion));

--- a/src/main/java/eu/europa/ted/efx/sdk0/v7/EfxTemplateTranslator.java
+++ b/src/main/java/eu/europa/ted/efx/sdk0/v7/EfxTemplateTranslator.java
@@ -1,6 +1,7 @@
 package eu.europa.ted.efx.sdk0.v7;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -116,6 +117,11 @@ public class EfxTemplateTranslator extends EfxExpressionTranslator {
   public static String renderTemplate(final String template,
       final TranslatorDependencyFactory factory, final String sdkVersion) {
     return renderTemplate(CharStreams.fromString(template), factory, sdkVersion);
+  }
+
+  public static String renderTemplate(final InputStream stream,
+      final TranslatorDependencyFactory factory, final String sdkVersion) throws IOException {
+    return renderTemplate(CharStreams.fromStream(stream), factory, sdkVersion);
   }
 
   private static String renderTemplate(final CharStream charStream,


### PR DESCRIPTION
We discovered and fixed this while investigating ticket https://citnet.tech.ec.europa.eu/CITnet/jira/browse/TEDEFO-1036 with Christophe.
