### PR TITLE
XPathScriptGenerator: Use urlPrefix variable for notice reference

### DIFF
--- a/src/main/java/eu/europa/ted/efx/xpath/XPathScriptGenerator.java
+++ b/src/main/java/eu/europa/ted/efx/xpath/XPathScriptGenerator.java
@@ -250,9 +250,8 @@ public class XPathScriptGenerator implements ScriptGenerator {
 
   @Override
   public PathExpression composeExternalReference(StringExpression externalReference) {
-    // TODO: implement this properly.
     return new PathExpression(
-        "fn:doc(concat('http://notice.service/', " + externalReference.script + ")')");
+        "fn:doc(concat($urlPrefix, " + externalReference.script + "))");
   }
 
 

--- a/src/test/java/eu/europa/ted/efx/EfxExpressionTranslatorTest.java
+++ b/src/test/java/eu/europa/ted/efx/EfxExpressionTranslatorTest.java
@@ -1006,7 +1006,7 @@ class EfxExpressionTranslatorTest {
   @Test
   void testFieldReferenceInOtherNotice() {
     assertEquals(
-        "fn:doc(concat('http://notice.service/', 'da4d46e9-490b-41ff-a2ae-8166d356a619')')/PathNode/TextField/normalize-space(text())",
+        "fn:doc(concat($urlPrefix, 'da4d46e9-490b-41ff-a2ae-8166d356a619'))/PathNode/TextField/normalize-space(text())",
         test("ND-Root", "notice('da4d46e9-490b-41ff-a2ae-8166d356a619')/BT-00-Text"));
   }
 


### PR DESCRIPTION
This variable contains the URL of the web service to use to fetch a
notice, and is defined in a the config.sch file that is included in the
Schematron files.