### PR TITLE
Align map get with containsKey

### DIFF
--- a/src/main/java/eu/europa/ted/efx/model/CallStack.java
+++ b/src/main/java/eu/europa/ted/efx/model/CallStack.java
@@ -44,7 +44,7 @@ public class CallStack extends Stack<CallStackObjectBase> {
     if (this.parameterValues.containsKey(variableName)) {
       this.push(parameterValues.get(variableName));
     } else if (this.variableTypes.containsKey(variableName)) {
-      this.push(Expression.instantiate(variableReference.script, variableTypes.get(variableReference.script)));
+      this.push(Expression.instantiate(variableReference.script, variableTypes.get(variableName)));
     } else {
       throw new ParseCancellationException("A variable or parameter with the name " + variableName + " has not been declared.");
     }


### PR DESCRIPTION
The current implementation leads to a NPE when the ScriptGenerator's
composeVariableReference returns a script that is anything other than
exactly the variable name.