### PR TITLE
TEDEFO-1394 Fields pointing to attributes now correctly translate to …

### DIFF
--- a/src/main/java/eu/europa/ted/efx/xpath/XPathScriptGenerator.java
+++ b/src/main/java/eu/europa/ted/efx/xpath/XPathScriptGenerator.java
@@ -96,7 +96,7 @@ public class XPathScriptGenerator implements ScriptGenerator {
   @Override
   public <T extends Expression> T composeFieldAttributeReference(PathExpression fieldReference,
       String attribute, Class<T> type) {
-    return Expression.instantiate(fieldReference.script + "/@" + attribute, type);
+    return Expression.instantiate(fieldReference.script + (fieldReference.script.isEmpty() ? "" : "/") + "@" + attribute, type);
   }
 
   @Override

--- a/src/test/java/eu/europa/ted/efx/EfxExpressionTranslatorTest.java
+++ b/src/test/java/eu/europa/ted/efx/EfxExpressionTranslatorTest.java
@@ -991,8 +991,19 @@ class EfxExpressionTranslatorTest {
   }
 
   @Test
+  void testFieldAttributeValueReference_SameElementContext() {
+    assertEquals("@Attribute = 'text'",
+        test("BT-00-Text", "BT-00-Attribute == 'text'"));
+  }
+
+  @Test
   void testScalarFromAttributeReference() {
     assertEquals("PathNode/CodeField/@listName", test("ND-Root", "BT-00-Code/@listName"));
+  }
+  
+  @Test
+  void testScalarFromAttributeReference_SameElementContext() {
+    assertEquals("./@listName", test("BT-00-Code", "BT-00-Code/@listName"));
   }
 
   @Test


### PR DESCRIPTION
…XPath when the context is the XML element containing the field.