### PR TITLE
Bugfix/TEDEFO-2311-like-pattern-expression-and-multilingual-text-fields

### DIFF
--- a/src/main/java/eu/europa/ted/efx/interfaces/ScriptGenerator.java
+++ b/src/main/java/eu/europa/ted/efx/interfaces/ScriptGenerator.java
@@ -368,9 +368,58 @@ public interface ScriptGenerator {
 
   public StringExpression composeToStringConversion(NumericExpression number);
 
+  /**
+   * Returns the target language script that converts the given text to upper case.
+   * 
+   * @since SDK 2.0.0
+   * @see #composeToLowerCaseConversion(StringExpression)
+   * 
+   * @param text The text to be converted to upper case.
+   * @return     The target language script that converts the text to upper case.
+   */
   public StringExpression composeToUpperCaseConversion(StringExpression text);
 
+  /**
+   * Returns the target language script that converts the given text to lower case.
+   * 
+   * @since SDK 2.0.0
+   * @see #composeToUpperCaseConversion(StringExpression)
+   * 
+   * @param text   The text to be converted to lower case.
+   * @return       The target language script that converts the text to lower case.
+   */
   public StringExpression composeToLowerCaseConversion(StringExpression text);
+
+  /**
+   * Gets the target language script that retrieves the preferred language ID
+   * out of the languages available in the given field.
+   * 
+   * The function is intended to be used in a predicate to select the text in the preferred
+   * language. The function's implementation will typically have to depend on a runtime call 
+   * to a runtime library function that retrieves the language identifiers that are preferred
+   * for the current visualisation.
+   * 
+   * @since SDK 2.0.0 
+   * @see #getTextInPreferredLanguage(PathExpression)
+   * 
+   * @param fieldReference  The multilingual text field.
+   * @return The target language script that retrieves the preferred language ID.
+   */
+  public StringExpression getPreferredLanguage(final PathExpression fieldReference);
+
+  /**
+   * Given a reference to a multilingual field, this function should generate the target language script
+   * that returns the text value of the field in the preferred language.
+   * 
+   * Calling the function in EFX 2
+   * 
+   * @since SDK 2.0.0
+   * @see #getPreferredLanguage(PathExpression)
+   * 
+   * @param fieldReference  The multilingual text field.
+   * @return The target language script that retrieves the field's text in the preferred language.
+   */
+  public StringExpression getTextInPreferredLanguage(final PathExpression fieldReference);
 
   /*
    * Boolean Functions

--- a/src/main/java/eu/europa/ted/efx/sdk1/xpath/XPathScriptGeneratorV1.java
+++ b/src/main/java/eu/europa/ted/efx/sdk1/xpath/XPathScriptGeneratorV1.java
@@ -1,0 +1,52 @@
+package eu.europa.ted.efx.sdk1.xpath;
+
+import eu.europa.ted.eforms.sdk.component.SdkComponent;
+import eu.europa.ted.eforms.sdk.component.SdkComponentType;
+import eu.europa.ted.efx.interfaces.TranslatorOptions;
+import eu.europa.ted.efx.model.Expression;
+import eu.europa.ted.efx.model.Expression.MultilingualStringExpression;
+import eu.europa.ted.efx.model.Expression.MultilingualStringListExpression;
+import eu.europa.ted.efx.model.Expression.PathExpression;
+import eu.europa.ted.efx.xpath.XPathContextualizer;
+import eu.europa.ted.efx.xpath.XPathScriptGenerator;
+
+@SdkComponent(versions = {"0.6", "0.7", "1"}, componentType = SdkComponentType.SCRIPT_GENERATOR)
+public class XPathScriptGeneratorV1 extends XPathScriptGenerator {
+
+    public XPathScriptGeneratorV1(TranslatorOptions translatorOptions) {
+        super(translatorOptions);
+    }
+
+    /***
+     * This method is overridden to workaround a limitation of EFX 1.
+     * 
+     * When a multilingual text field is referenced, then a special XPath expression
+     * is generated to retrieve the value in the "preferred" language.
+     * Preferred language is the first language among the languages listed in the
+     * translator options for which a text value is available in the field.
+     * 
+     * The logic of the workaround is as follows:
+     * if the fieldReference is a multilingual text field and it does not
+     * already come with a predicate that filters by @languageID, then we add a
+     * predicate which, using a for loop, will find the first language for which a
+     * value is available in the field.
+     * 
+     * In EFX 1 therefore the selection of the appropriate (preferred) language is
+     * done implicitly, whereas in EFX 2 it is done explicitly by calling a special
+     * function designed to perform this task.
+     * 
+     * Both EFX and EFX 2 implementations of the feature rely on the existence of a
+     * "ted:preferred-languages()" function in the XSLT.
+     * This function returns the list of languages used in the visualisation in the
+     * order of preference (visualisation language followed by notice language(s)).
+     */
+    @Override
+    public <T extends Expression> T composeFieldValueReference(PathExpression fieldReference, Class<T> type) {
+        if ((MultilingualStringExpression.class.isAssignableFrom(type) || MultilingualStringListExpression.class.isAssignableFrom(type)) && !XPathContextualizer.hasPredicate(fieldReference, "@languageID")) {
+            PathExpression languageSpecific = XPathContextualizer.addPredicate(fieldReference, "@languageID=$__LANG__");
+            String script = "(for $__LANG__ in ted:preferred-languages() return " + languageSpecific.script + "/normalize-space(text()), " + fieldReference.script + "/normalize-space(text()))[1]";
+            return Expression.instantiate(script, type);
+          }
+        return super.composeFieldValueReference(fieldReference, type);
+    }
+}

--- a/src/main/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2.java
+++ b/src/main/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2.java
@@ -1069,6 +1069,12 @@ public class EfxExpressionTranslatorV2 extends EfxBaseListener
         this.getAttributeName(ctx), StringExpression.class));
   }
 
+  @Override
+  public void exitSequenceFromAttributeReference(SequenceFromAttributeReferenceContext ctx) {
+    this.stack.push(this.script.composeFieldAttributeReference(this.stack.pop(PathExpression.class),
+        this.getAttributeName(ctx), StringListExpression.class));
+  }
+
   // #endregion Value References ----------------------------------------------
 
   // #region References with context override ---------------------------------
@@ -1624,6 +1630,10 @@ public class EfxExpressionTranslatorV2 extends EfxBaseListener
 
   protected String getAttributeName(String efxAttributeIdentifier) {
     return StringUtils.substringAfter(efxAttributeIdentifier, ATTRIBUTE_PREFIX);
+  }
+
+  private String getAttributeName(SequenceFromAttributeReferenceContext ctx) {
+    return this.getAttributeName(ctx.attributeReference().Attribute().getText());
   }
 
   private String getAttributeName(ScalarFromAttributeReferenceContext ctx) {

--- a/src/main/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2.java
+++ b/src/main/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2.java
@@ -1448,6 +1448,16 @@ public class EfxExpressionTranslatorV2 extends EfxBaseListener
     this.stack.push(this.script.composeNumberFormatting(number, format));
   }
 
+  @Override
+  public void exitPreferredLanguageFunction(PreferredLanguageFunctionContext ctx) {
+    this.stack.push(this.script.getPreferredLanguage(this.stack.pop(PathExpression.class)));
+  }
+
+  @Override
+  public void exitPreferredLanguageTextFunction(PreferredLanguageTextFunctionContext ctx) {
+    this.stack.push(this.script.getTextInPreferredLanguage(this.stack.pop(PathExpression.class)));
+  }
+
   // #endregion String functions ----------------------------------------------
 
   // #region Date functions ---------------------------------------------------

--- a/src/main/java/eu/europa/ted/efx/xpath/XPathContextualizer.java
+++ b/src/main/java/eu/europa/ted/efx/xpath/XPathContextualizer.java
@@ -82,6 +82,14 @@ public class XPathContextualizer extends XPath20BaseListener {
     return getContextualizedXpath(contextSteps, pathSteps);
   }
 
+  public static boolean hasPredicate(final PathExpression xpath, String match) {
+    return hasPredicate(xpath.script, match);
+  }
+  
+  public static boolean hasPredicate(final String xpath, String match) {
+    return getSteps(xpath).stream().anyMatch(s -> s.getPredicateText().contains(match));
+  }
+
   public static PathExpression addPredicate(final PathExpression pathExpression, final String predicate) {
     return new PathExpression(addPredicate(pathExpression.script, predicate));
   }

--- a/src/main/java/eu/europa/ted/efx/xpath/XPathScriptGenerator.java
+++ b/src/main/java/eu/europa/ted/efx/xpath/XPathScriptGenerator.java
@@ -1,6 +1,7 @@
 package eu.europa.ted.efx.xpath;
 
 import static java.util.Map.entry;
+
 import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.Map;
@@ -8,7 +9,9 @@ import java.util.StringJoiner;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
 import org.antlr.v4.runtime.misc.ParseCancellationException;
+
 import eu.europa.ted.eforms.sdk.component.SdkComponent;
 import eu.europa.ted.eforms.sdk.component.SdkComponentType;
 import eu.europa.ted.efx.interfaces.ScriptGenerator;
@@ -22,8 +25,6 @@ import eu.europa.ted.efx.model.Expression.DurationListExpression;
 import eu.europa.ted.efx.model.Expression.IteratorExpression;
 import eu.europa.ted.efx.model.Expression.IteratorListExpression;
 import eu.europa.ted.efx.model.Expression.ListExpression;
-import eu.europa.ted.efx.model.Expression.MultilingualStringExpression;
-import eu.europa.ted.efx.model.Expression.MultilingualStringListExpression;
 import eu.europa.ted.efx.model.Expression.NumericExpression;
 import eu.europa.ted.efx.model.Expression.NumericListExpression;
 import eu.europa.ted.efx.model.Expression.PathExpression;
@@ -32,7 +33,7 @@ import eu.europa.ted.efx.model.Expression.StringListExpression;
 import eu.europa.ted.efx.model.Expression.TimeExpression;
 import eu.europa.ted.efx.model.Expression.TimeListExpression;
 
-@SdkComponent(versions = {"0.6", "0.7", "1", "2"},
+@SdkComponent(versions = {"2"},
     componentType = SdkComponentType.SCRIPT_GENERATOR)
 public class XPathScriptGenerator implements ScriptGenerator {
 
@@ -78,13 +79,6 @@ public class XPathScriptGenerator implements ScriptGenerator {
   @Override
   public <T extends Expression> T composeFieldValueReference(PathExpression fieldReference,
       Class<T> type) {
-
-    if (MultilingualStringExpression.class.isAssignableFrom(type) || MultilingualStringListExpression.class.isAssignableFrom(type)) {
-      String languages = "('" + String.join("','", this.translatorOptions.getAllLanguage3LetterCodes()) + "')";
-      PathExpression languageSpecific = XPathContextualizer.addPredicate(fieldReference, "@languageID=$__LANG__");
-      String script = "(for $__LANG__ in " + languages + " return " + languageSpecific.script + "/normalize-space(text()), " + fieldReference.script + "/normalize-space(text()))[1]";
-      return Expression.instantiate(script, type);
-    }
     if (StringExpression.class.isAssignableFrom(type) || StringListExpression.class.isAssignableFrom(type)) {
       return Expression.instantiate(fieldReference.script + "/normalize-space(text())", type);
     }
@@ -301,7 +295,7 @@ public class XPathScriptGenerator implements ScriptGenerator {
     return XPathContextualizer.join(first, second);
   }
 
-  /** Indexers ***/
+  //#region Indexers ----------------------------------------------------------
 
   @Override
   public <T extends Expression, L extends ListExpression<T>> T composeIndexer(L list,
@@ -310,7 +304,9 @@ public class XPathScriptGenerator implements ScriptGenerator {
     return Expression.instantiate(String.format("%s[%s]", list.script, index.script), type);
   }
 
-  /*** BooleanExpressions ***/
+  //#endregion Indexers -------------------------------------------------------
+
+  //#region Boolean Expressions -----------------------------------------------
 
 
   @Override
@@ -344,7 +340,9 @@ public class XPathScriptGenerator implements ScriptGenerator {
         + "[. = $x] return $y) = 1");
   }
 
-  /*** Boolean functions ***/
+  //#endregion Boolean Expressions ------------------------------------------
+
+  //#region Boolean functions -----------------------------------------------
 
   @Override
   public BooleanExpression composeContainsCondition(StringExpression haystack,
@@ -384,7 +382,9 @@ public class XPathScriptGenerator implements ScriptGenerator {
     return new BooleanExpression("deep-equal(sort(" + one.script + "), sort(" + two.script + "))");
   }
 
-  /*** Numeric functions ***/
+  //#endregion Boolean functions ----------------------------------------------
+
+  //#region Numeric functions -------------------------------------------------
 
   @Override
   public NumericExpression composeCountOperation(PathExpression nodeSet) {
@@ -423,8 +423,9 @@ public class XPathScriptGenerator implements ScriptGenerator {
         leftOperand.script + " " + operators.get(operator) + " " + rightOperand.script);
   }
 
+  //#endregion Numeric functions ----------------------------------------------
 
-  /*** String functions ***/
+  //#region String functions --------------------------------------------------
 
   @Override
   public StringExpression composeSubstringExtraction(StringExpression text, NumericExpression start,
@@ -479,8 +480,23 @@ public class XPathScriptGenerator implements ScriptGenerator {
     return new StringExpression("'" + value + "'", true);
   }
 
+  @Override
+  public StringExpression getPreferredLanguage(PathExpression fieldReference) {
+    final String variableName = "$__LANG__";
+      String languages = "('" + String.join("','", this.translatorOptions.getAllLanguage3LetterCodes()) + "')";
+      PathExpression languageSpecific = XPathContextualizer.addPredicate(fieldReference, "@languageID=" + variableName);
+      String script = "((for " + variableName + " in " + languages + " return if (" + languageSpecific.script + "/normalize-space(text())) then " + variableName + " else ()), " + fieldReference.script + "/normalize-space(text()))[1]";
+    return new StringExpression(script);
+  }
 
-  /*** Date functions ***/
+  @Override
+  public StringExpression getTextInPreferredLanguage(PathExpression fieldReference) {
+    return new StringExpression(XPathContextualizer.addPredicate(fieldReference, "[@languageID=" + this.getPreferredLanguage(fieldReference).script + "]").script );
+  }
+
+  //#endregion String functions -----------------------------------------------
+
+  //#region Date functions ----------------------------------------------------
 
   @Override
   public DateExpression composeToDateConversion(StringExpression date) {
@@ -497,15 +513,18 @@ public class XPathScriptGenerator implements ScriptGenerator {
     return new DateExpression("(" + date.script + " - " + duration.script + ")");
   }
 
-  /*** Time functions ***/
+  //#endregion Date functions -------------------------------------------------
+
+  //#region Time functions ----------------------------------------------------
 
   @Override
   public TimeExpression composeToTimeConversion(StringExpression time) {
     return new TimeExpression("xs:time(" + time.script + ")");
   }
 
+  //#endregion Time functions -------------------------------------------------
 
-  /*** Duration functions ***/
+  //#region Duration functions ------------------------------------------------
 
   @Override
   public DurationExpression composeToDayTimeDurationConversion(StringExpression text) {
@@ -563,8 +582,9 @@ public class XPathScriptGenerator implements ScriptGenerator {
     return Expression.instantiate("distinct-values(for $L1 in " + listOne.script + " return if (every $L2 in " + listTwo.script + " satisfies $L1 != $L2) then $L1 else ())", listType);
   }
 
+  //#endregion Duration functions ---------------------------------------------
 
-  /*** Helpers ***/
+  //#region Helpers -----------------------------------------------------------
 
 
   private String quoted(final String text) {
@@ -575,4 +595,6 @@ public class XPathScriptGenerator implements ScriptGenerator {
     Matcher weeksMatcher = Pattern.compile("(?<=[^0-9])[0-9]+(?=W)").matcher(literal);
     return weeksMatcher.find() ? Integer.parseInt(weeksMatcher.group()) : 0;
   }
+
+  //#endregion Helpers --------------------------------------------------------
 }

--- a/src/main/java/eu/europa/ted/efx/xpath/XPathScriptGenerator.java
+++ b/src/main/java/eu/europa/ted/efx/xpath/XPathScriptGenerator.java
@@ -483,9 +483,8 @@ public class XPathScriptGenerator implements ScriptGenerator {
   @Override
   public StringExpression getPreferredLanguage(PathExpression fieldReference) {
     final String variableName = "$__LANG__";
-      String languages = "('" + String.join("','", this.translatorOptions.getAllLanguage3LetterCodes()) + "')";
       PathExpression languageSpecific = XPathContextualizer.addPredicate(fieldReference, "@languageID=" + variableName);
-      String script = "((for " + variableName + " in " + languages + " return if (" + languageSpecific.script + "/normalize-space(text())) then " + variableName + " else ()), " + fieldReference.script + "/normalize-space(text()))[1]";
+      String script = "((for " + variableName + " in ted:preferred-languages() return if (" + languageSpecific.script + "/normalize-space(text())) then " + variableName + " else ()), " + fieldReference.script + "/normalize-space(text()))[1]";
     return new StringExpression(script);
   }
 

--- a/src/test/java/eu/europa/ted/efx/mock/DependencyFactoryMock.java
+++ b/src/test/java/eu/europa/ted/efx/mock/DependencyFactoryMock.java
@@ -1,14 +1,17 @@
 package eu.europa.ted.efx.mock;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.antlr.v4.runtime.BaseErrorListener;
 
+import eu.europa.ted.eforms.sdk.ComponentFactory;
 import eu.europa.ted.efx.exceptions.ThrowingErrorListener;
 import eu.europa.ted.efx.interfaces.MarkupGenerator;
 import eu.europa.ted.efx.interfaces.ScriptGenerator;
 import eu.europa.ted.efx.interfaces.SymbolResolver;
 import eu.europa.ted.efx.interfaces.TranslatorDependencyFactory;
 import eu.europa.ted.efx.interfaces.TranslatorOptions;
-import eu.europa.ted.efx.xpath.XPathScriptGenerator;
 
 /**
  * Provides EfxTranslator dependencies used for unit testing.
@@ -19,9 +22,9 @@ public class DependencyFactoryMock implements TranslatorDependencyFactory {
 
   final public static DependencyFactoryMock INSTANCE = new DependencyFactoryMock();
 
-  ScriptGenerator scriptGenerator;
-  MarkupGenerator markupGenerator;
-
+  Map<String, ScriptGenerator> scriptGenerators = new HashMap<>();
+  Map<String, MarkupGenerator> markupGenerators = new HashMap<>();
+  
   @Override
   public SymbolResolver createSymbolResolver(String sdkVersion) {
     return SymbolResolverMockFactory.getInstance(sdkVersion);
@@ -29,18 +32,22 @@ public class DependencyFactoryMock implements TranslatorDependencyFactory {
 
   @Override
   public ScriptGenerator createScriptGenerator(String sdkVersion, TranslatorOptions options) {
-    if (scriptGenerator == null) {
-      this.scriptGenerator = new XPathScriptGenerator(options);
+    if (!scriptGenerators.containsKey(sdkVersion)) {
+      try {
+        this.scriptGenerators.put(sdkVersion, ComponentFactory.getScriptGenerator(sdkVersion, options));
+      } catch (InstantiationException e) {
+        throw new RuntimeException(e.getMessage(), e);
+      }
     }
-    return this.scriptGenerator;
+    return this.scriptGenerators.get(sdkVersion);
   }
 
   @Override
   public MarkupGenerator createMarkupGenerator(String sdkVersion, TranslatorOptions options) {
-    if (this.markupGenerator == null) {
-      this.markupGenerator = new MarkupGeneratorMock();
+    if (!this.markupGenerators.containsKey(sdkVersion)) {
+      this.markupGenerators.put(sdkVersion, new MarkupGeneratorMock());
     }
-    return this.markupGenerator;
+    return this.markupGenerators.get(sdkVersion);
   }
 
   @Override

--- a/src/test/java/eu/europa/ted/efx/sdk1/EfxExpressionTranslatorV1Test.java
+++ b/src/test/java/eu/europa/ted/efx/sdk1/EfxExpressionTranslatorV1Test.java
@@ -90,7 +90,7 @@ class EfxExpressionTranslatorV1Test extends EfxTestsBase {
   @Test
   void testFieldValueComparison_UsingTextFields() {
     testExpressionTranslationWithContext(
-        "PathNode/TextField/normalize-space(text()) = (for $__LANG__ in ('eng') return PathNode/TextMultilingualField[@languageID=$__LANG__]/normalize-space(text()), PathNode/TextMultilingualField/normalize-space(text()))[1]",
+        "PathNode/TextField/normalize-space(text()) = (for $__LANG__ in ted:preferred-languages() return PathNode/TextMultilingualField[@languageID=$__LANG__]/normalize-space(text()), PathNode/TextMultilingualField/normalize-space(text()))[1]",
         "ND-Root", "BT-00-Text == BT-00-Text-Multilingual");
   }
 
@@ -1115,6 +1115,18 @@ class EfxExpressionTranslatorV1Test extends EfxTestsBase {
   void testFieldReference_WithAxis() {
     testExpressionTranslationWithContext("./preceding::PathNode/IntegerField/number()", "ND-Root",
         "ND-Root::preceding::BT-00-Integer");
+  }
+
+  @Test
+  void testMultilingualTextFieldReference() {
+    testExpressionTranslationWithContext("(for $__LANG__ in ted:preferred-languages() return PathNode/TextMultilingualField[@languageID=$__LANG__]/normalize-space(text()), PathNode/TextMultilingualField/normalize-space(text()))[1]",
+        "ND-Root", "BT-00-Text-Multilingual");
+  }
+
+  @Test
+  void testMultilingualTextFieldReference_WithLanguagePredicate() {
+    testExpressionTranslationWithContext("PathNode/TextMultilingualField[./@languageID = 'eng']/normalize-space(text())",
+        "ND-Root", "BT-00-Text-Multilingual[BT-00-Text-Multilingual/@languageID == 'eng']");
   }
 
   // #endregion: References

--- a/src/test/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2Test.java
+++ b/src/test/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2Test.java
@@ -101,13 +101,13 @@ class EfxExpressionTranslatorV2Test extends EfxTestsBase {
 
   @Test 
   void testVisualisationLanguageFunction() {
-    testExpressionTranslation("PathNode/TextMultilingualField[./@languageID = ((for $__LANG__ in ('eng') return if (.[@languageID=$__LANG__]/normalize-space(text())) then $__LANG__ else ()), ./normalize-space(text()))[1]]/normalize-space(text())", 
+    testExpressionTranslation("PathNode/TextMultilingualField[./@languageID = ((for $__LANG__ in ted:preferred-languages() return if (.[@languageID=$__LANG__]/normalize-space(text())) then $__LANG__ else ()), ./normalize-space(text()))[1]]/normalize-space(text())", 
     "{ND-Root} ${BT-00-Text-Multilingual[BT-00-Text-Multilingual/@languageID == preferred-language(BT-00-Text-Multilingual)]}");
   }
 
   @Test 
   void testGetPreferredLanguageTextFunction() {
-    testExpressionTranslation("PathNode/TextMultilingualField[@languageID=((for $__LANG__ in ('eng') return if (PathNode/TextMultilingualField[@languageID=$__LANG__]/normalize-space(text())) then $__LANG__ else ()), PathNode/TextMultilingualField/normalize-space(text()))[1]]", 
+    testExpressionTranslation("PathNode/TextMultilingualField[@languageID=((for $__LANG__ in ted:preferred-languages() return if (PathNode/TextMultilingualField[@languageID=$__LANG__]/normalize-space(text())) then $__LANG__ else ()), PathNode/TextMultilingualField/normalize-space(text()))[1]]", 
     "{ND-Root} ${preferred-language-text(BT-00-Text-Multilingual)}");
   }
 
@@ -1142,11 +1142,11 @@ class EfxExpressionTranslatorV2Test extends EfxTestsBase {
   }
 
   /**
-   * Unlike EFX-1, where any reference toa text-multilingual field, is automatically translated to
+   * Unlike EFX-1, where any reference to a text-multilingual field, is automatically translated to
    * an expression that returns the value of the field in the preferred language, in EFX-2 there are
    * no such implicit assumptions made. In EFX-2 a reference to a text-multilingual field behaves just 
    * like any other field reference. To get the value of the field in a specific language you either need
-   * to add a predicate that selects it or use the in-preferred-language function. 
+   * to add a predicate that selects it or use the preferred-language-text function. 
    */
   @Test
   void testMultilingualTextFieldReference() {

--- a/src/test/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2Test.java
+++ b/src/test/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2Test.java
@@ -88,9 +88,33 @@ class EfxExpressionTranslatorV2Test extends EfxTestsBase {
   }
 
   @Test
+  void testLikePatternCondition_WithTextField() {
+    testExpressionTranslation("fn:matches(normalize-space(PathNode/TextField/normalize-space(text())), '[0-9]*')",
+        "{ND-Root} ${BT-00-Text like '[0-9]*'}");
+  }
+
+  @Test
+  void testLikePatternCondition_WithTextMultilingualField() {
+    testExpressionTranslation("every $lang in PathNode/TextMultilingualField/@languageID satisfies fn:matches(normalize-space(PathNode/TextMultilingualField[./@languageID = $lang]/normalize-space(text())), '[0-9]*')",
+        "{ND-Root} ${every text:$lang in BT-00-Text-Multilingual/@languageID satisfies BT-00-Text-Multilingual[BT-00-Text-Multilingual/@languageID == $lang]  like '[0-9]*'}");
+  }
+
+  @Test 
+  void testVisualisationLanguageFunction() {
+    testExpressionTranslation("PathNode/TextMultilingualField[./@languageID = ((for $__LANG__ in ('eng') return if (.[@languageID=$__LANG__]/normalize-space(text())) then $__LANG__ else ()), ./normalize-space(text()))[1]]/normalize-space(text())", 
+    "{ND-Root} ${BT-00-Text-Multilingual[BT-00-Text-Multilingual/@languageID == preferred-language(BT-00-Text-Multilingual)]}");
+  }
+
+  @Test 
+  void testGetPreferredLanguageTextFunction() {
+    testExpressionTranslation("PathNode/TextMultilingualField[@languageID=((for $__LANG__ in ('eng') return if (PathNode/TextMultilingualField[@languageID=$__LANG__]/normalize-space(text())) then $__LANG__ else ()), PathNode/TextMultilingualField/normalize-space(text()))[1]]", 
+    "{ND-Root} ${preferred-language-text(BT-00-Text-Multilingual)}");
+  }
+
+  @Test
   void testFieldValueComparison_UsingTextFields() {
     testExpressionTranslationWithContext(
-        "PathNode/TextField/normalize-space(text()) = (for $__LANG__ in ('eng') return PathNode/TextMultilingualField[@languageID=$__LANG__]/normalize-space(text()), PathNode/TextMultilingualField/normalize-space(text()))[1]",
+        "PathNode/TextField/normalize-space(text()) = PathNode/TextMultilingualField/normalize-space(text())",
         "Root", "textField == textMultilingualField");
   }
 
@@ -1116,6 +1140,26 @@ class EfxExpressionTranslatorV2Test extends EfxTestsBase {
     testExpressionTranslationWithContext("./preceding::PathNode/IntegerField/number()", "ND-Root",
         "ND-Root::preceding::integerField");
   }
+
+  /**
+   * Unlike EFX-1, where any reference toa text-multilingual field, is automatically translated to
+   * an expression that returns the value of the field in the preferred language, in EFX-2 there are
+   * no such implicit assumptions made. In EFX-2 a reference to a text-multilingual field behaves just 
+   * like any other field reference. To get the value of the field in a specific language you either need
+   * to add a predicate that selects it or use the in-preferred-language function. 
+   */
+  @Test
+  void testMultilingualTextFieldReference() {
+    testExpressionTranslationWithContext("PathNode/TextMultilingualField/normalize-space(text())",
+        "ND-Root", "BT-00-Text-Multilingual");
+  }
+
+  @Test
+  void testMultilingualTextFieldReference_WithLanguagePredicate() {
+    testExpressionTranslationWithContext("PathNode/TextMultilingualField[./@languageID = 'eng']/normalize-space(text())",
+        "ND-Root", "BT-00-Text-Multilingual[BT-00-Text-Multilingual/@languageID == 'eng']");
+  }
+
 
   // #endregion: References
 


### PR DESCRIPTION
Addes a better implementation for multilingual text resolution (two new EFX-2 functions). Adds a workaround for having a similar implicit functionality in EFX 1. Fixes a bug in the expression translator.