### PR TITLE
Fixes #88. Date and time formatting now works correctly with sequences.

### DIFF
--- a/src/main/java/eu/europa/ted/efx/sdk1/EfxTemplateTranslatorV1.java
+++ b/src/main/java/eu/europa/ted/efx/sdk1/EfxTemplateTranslatorV1.java
@@ -29,8 +29,11 @@ import eu.europa.ted.efx.model.expressions.Expression;
 import eu.europa.ted.efx.model.expressions.TypedExpression;
 import eu.europa.ted.efx.model.expressions.path.PathExpression;
 import eu.europa.ted.efx.model.expressions.path.StringPathExpression;
+import eu.europa.ted.efx.model.expressions.scalar.DateExpression;
 import eu.europa.ted.efx.model.expressions.scalar.StringExpression;
+import eu.europa.ted.efx.model.expressions.sequence.DateSequenceExpression;
 import eu.europa.ted.efx.model.expressions.sequence.StringSequenceExpression;
+import eu.europa.ted.efx.model.expressions.sequence.TimeSequenceExpression;
 import eu.europa.ted.efx.model.templates.ContentBlock;
 import eu.europa.ted.efx.model.templates.ContentBlockStack;
 import eu.europa.ted.efx.model.templates.Markup;
@@ -496,9 +499,29 @@ public class EfxTemplateTranslatorV1 extends EfxExpressionTranslatorV1
     // functions.
     if (TypedExpression.class.isAssignableFrom(expression.getClass())) {
       if (EfxDataType.Date.class.isAssignableFrom(((TypedExpression) expression).getDataType())) {
-        expression = new StringExpression("format-date(" + expression.getScript() + ", '[D01]/[M01]/[Y0001]')");
+
+        var loopVariable = new Variable("item",
+            this.script.composeVariableDeclaration("item", DateExpression.class), DateExpression.empty(),
+            this.script.composeVariableReference("item", DateExpression.class));
+
+        expression = this.script.composeForExpression(
+            this.script.composeIteratorList(
+                List.of(this.script.composeIteratorExpression(loopVariable.declarationExpression,
+                    new DateSequenceExpression(expression.getScript())))),
+            new StringExpression("format-date($item, '[D01]/[M01]/[Y0001]')"),
+            StringSequenceExpression.class);
       } else if (EfxDataType.Time.class.isAssignableFrom(((TypedExpression) expression).getDataType())) {
-        expression = new StringExpression("format-time(" + expression.getScript() + ", '[H01]:[m01] [Z]')");
+
+        var loopVariable = new Variable("item",
+            this.script.composeVariableDeclaration("item", DateExpression.class), DateExpression.empty(),
+            this.script.composeVariableReference("item", DateExpression.class));
+
+        expression = this.script.composeForExpression(
+            this.script.composeIteratorList(
+                List.of(this.script.composeIteratorExpression(loopVariable.declarationExpression,
+                    new TimeSequenceExpression(expression.getScript())))),
+            new StringExpression("format-time($item, '[H01]:[m01] [Z]')"),
+            StringSequenceExpression.class);
       }
     }
 

--- a/src/main/java/eu/europa/ted/efx/sdk2/EfxTemplateTranslatorV2.java
+++ b/src/main/java/eu/europa/ted/efx/sdk2/EfxTemplateTranslatorV2.java
@@ -38,7 +38,9 @@ import eu.europa.ted.efx.model.expressions.scalar.NumericExpression;
 import eu.europa.ted.efx.model.expressions.scalar.ScalarExpression;
 import eu.europa.ted.efx.model.expressions.scalar.StringExpression;
 import eu.europa.ted.efx.model.expressions.scalar.TimeExpression;
+import eu.europa.ted.efx.model.expressions.sequence.DateSequenceExpression;
 import eu.europa.ted.efx.model.expressions.sequence.StringSequenceExpression;
+import eu.europa.ted.efx.model.expressions.sequence.TimeSequenceExpression;
 import eu.europa.ted.efx.model.templates.ContentBlock;
 import eu.europa.ted.efx.model.templates.ContentBlockStack;
 import eu.europa.ted.efx.model.templates.Markup;
@@ -559,9 +561,29 @@ public class EfxTemplateTranslatorV2 extends EfxExpressionTranslatorV2
     // functions.
     if (TypedExpression.class.isAssignableFrom(expression.getClass())) {
       if (EfxDataType.Date.class.isAssignableFrom(((TypedExpression) expression).getDataType())) {
-        expression = new StringExpression("format-date(" + expression.getScript() + ", '[D01]/[M01]/[Y0001]')");
+
+        var loopVariable = new Variable("item",
+            this.script.composeVariableDeclaration("item", DateExpression.class), DateExpression.empty(),
+            this.script.composeVariableReference("item", DateExpression.class));
+
+        expression = this.script.composeForExpression(
+            this.script.composeIteratorList(
+                List.of(this.script.composeIteratorExpression(loopVariable.declarationExpression,
+                    new DateSequenceExpression(expression.getScript())))),
+            new StringExpression("format-date($item, '[D01]/[M01]/[Y0001]')"),
+            StringSequenceExpression.class);
       } else if (EfxDataType.Time.class.isAssignableFrom(((TypedExpression) expression).getDataType())) {
-        expression = new StringExpression("format-time(" + expression.getScript() + ", '[H01]:[m01] [Z]')");
+
+        var loopVariable = new Variable("item",
+            this.script.composeVariableDeclaration("item", DateExpression.class), DateExpression.empty(),
+            this.script.composeVariableReference("item", DateExpression.class));
+
+        expression = this.script.composeForExpression(
+            this.script.composeIteratorList(
+                List.of(this.script.composeIteratorExpression(loopVariable.declarationExpression,
+                    new TimeSequenceExpression(expression.getScript())))),
+            new StringExpression("format-time($item, '[H01]:[m01] [Z]')"),
+            StringSequenceExpression.class);
       }
     }
 

--- a/src/test/java/eu/europa/ted/efx/sdk1/EfxTemplateTranslatorV1Test.java
+++ b/src/test/java/eu/europa/ted/efx/sdk1/EfxTemplateTranslatorV1Test.java
@@ -353,11 +353,11 @@ class EfxTemplateTranslatorV1Test extends EfxTestsBase {
 
   @Test
   void testImplicitFormatting_Dates() {
-    assertEquals("let block01() -> { eval(format-date(PathNode/StartDateField/xs:date(text()), '[D01]/[M01]/[Y0001]')) }\nfor-each(/*).call(block01())", translateTemplate("{ND-Root} ${BT-00-StartDate}"));
-  } 
+    assertEquals("let block01() -> { eval(for $item in PathNode/StartDateField/xs:date(text()) return format-date($item, '[D01]/[M01]/[Y0001]')) }\nfor-each(/*).call(block01())", translateTemplate("{ND-Root} ${BT-00-StartDate}"));
+  }
 
   @Test
   void testImplicitFormatting_Times() {
-    assertEquals("let block01() -> { eval(format-time(PathNode/StartTimeField/xs:time(text()), '[H01]:[m01] [Z]')) }\nfor-each(/*).call(block01())", translateTemplate("{ND-Root} ${BT-00-StartTime}"));
-  } 
+    assertEquals("let block01() -> { eval(for $item in PathNode/StartTimeField/xs:time(text()) return format-time($item, '[H01]:[m01] [Z]')) }\nfor-each(/*).call(block01())", translateTemplate("{ND-Root} ${BT-00-StartTime}"));
+  }
 }


### PR DESCRIPTION
This is a fix for OP-TED/eforms-notice-viewer#88 (TEDEFO-3108).