### PR TITLE
Update dependencies on eforms-core and antlr4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <version.pgp.plugin>1.5</version.pgp.plugin>
     <version.nexus-staging.plugin>1.6.7</version.nexus-staging.plugin>
     <version.source.plugin>3.2.1</version.source.plugin>
-    <version.surefire.plugin>3.0.0-M7</version.surefire.plugin> <!-- Versions prior to 3.0.x do not pick up Junit 5 tests correctly. -->
+    <version.surefire.plugin>3.2.5</version.surefire.plugin>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,10 @@
     <sdk.antlr4.dir>${project.build.directory}/eforms-sdk/antlr4</sdk.antlr4.dir>
 
     <!-- Versions - eForms -->
-    <version.eforms-core>1.3.0</version.eforms-core>
+    <version.eforms-core>1.4.0-SNAPSHOT</version.eforms-core>
 
     <!-- Versions - Third-party libraries -->
-    <version.antlr4>4.9.3</version.antlr4>
+    <version.antlr4>4.13.1</version.antlr4>
     <version.commons-lang3>3.12.0</version.commons-lang3>
     <version.logback>1.2.11</version.logback>
     <version.jackson>2.13.4</version.jackson>


### PR DESCRIPTION
This requires the change in PR OP-TED/eforms-core-java#31, so that both libraries use the same version of Antlr4. That's because parsers generated by Antlr4 4.9 (which we used before this change) are not compatible with Antlr4 4.10 and above.

So it is expected that the build here will fail until that PR is merged.