### PR TITLE
Revert "ComponentFactory: Improve SymbolResolver creation (TEDEFO-3286)"

### DIFF
--- a/src/main/java/eu/europa/ted/eforms/sdk/ComponentFactory.java
+++ b/src/main/java/eu/europa/ted/eforms/sdk/ComponentFactory.java
@@ -86,30 +86,13 @@ public class ComponentFactory extends SdkComponentFactory {
    */
   public static SymbolResolver getSymbolResolver(final String sdkVersion, final String qualifier,
       final Path sdkRootPath) throws InstantiationException {
-    return getSymbolResolver(sdkVersion, qualifier, sdkRootPath);
-  }
-
-  /**
-   * Gets the single instance containing the symbols defined in the given version of the eForms SDK.
-   *
-   * @param sdkVersion Version of the SDK
-   * @param qualifier Qualifier to choose between several implementations
-   * @param parameters Array of objects to be passed as arguments to the constructor of the
-   * SymbolResolver implementation
-   * @return The single instance containing the symbols defined in the given version of the eForms
-   *        SDK.
-   * @throws InstantiationException If the SDK version is not supported.
-   */
-  public static SymbolResolver getSymbolResolver(final String sdkVersion, final String qualifier,
-      Object... parameters) throws InstantiationException {
-
     VersionQualifier key = ComponentFactory.INSTANCE.new VersionQualifier(sdkVersion, qualifier);
 
     return instances.computeIfAbsent(key, k -> {
       try {
         return ComponentFactory.INSTANCE.getComponentImpl(sdkVersion,
             SdkComponentType.SYMBOL_RESOLVER, qualifier, SymbolResolver.class, sdkVersion,
-            parameters);
+            sdkRootPath);
       } catch (InstantiationException e) {
         throw new RuntimeException(MessageFormat.format(
             "Failed to instantiate SDK Symbol Resolver for SDK version [{0}]", sdkVersion), e);


### PR DESCRIPTION
This reverts commit 9b8a7de5a6beee7ad5326058fe334f2c05c06e3b. It introduced an infinite loop, causing a StackOverflowError.