### PR TITLE
Fixed the order of variable declarations passed to the MarkupGenerator.

### DIFF
--- a/src/main/java/eu/europa/ted/efx/model/templates/ContentBlock.java
+++ b/src/main/java/eu/europa/ted/efx/model/templates/ContentBlock.java
@@ -125,7 +125,7 @@ public class ContentBlock {
     if (this.context != null && this.context.variable() != null) {
       variables.add(this.context.variable());
     }
-    variables.addAll(this.variables);
+    variables.addAll(this.variables.declaredOrder());
     return variables;
   }
 

--- a/src/main/java/eu/europa/ted/efx/model/variables/VariableList.java
+++ b/src/main/java/eu/europa/ted/efx/model/variables/VariableList.java
@@ -1,5 +1,6 @@
 package eu.europa.ted.efx.model.variables;
 
+import java.util.Collections;
 import java.util.LinkedList;
 
 import eu.europa.ted.efx.model.ParsedEntity;
@@ -7,5 +8,12 @@ import eu.europa.ted.efx.model.ParsedEntity;
 public class VariableList extends LinkedList<Variable> implements ParsedEntity {
 
   public VariableList() {
+  }
+
+  public VariableList declaredOrder() {
+    VariableList reversedList = new VariableList();
+    reversedList.addAll(this);
+    Collections.reverse(reversedList);
+    return reversedList;
   }
 }


### PR DESCRIPTION
TEDEFO-3343 is a bug about EFXT context variables being rendered in the XSL output in the reverse order from which they were declared.