### PR TITLE
Fixed the ordering of context  variables and parameters

### DIFF
--- a/src/main/java/eu/europa/ted/efx/model/templates/ContentBlock.java
+++ b/src/main/java/eu/europa/ted/efx/model/templates/ContentBlock.java
@@ -122,9 +122,6 @@ public class ContentBlock {
 
   public Set<Variable> getOwnVariables() {
     Set<Variable> variables = new LinkedHashSet<>();
-    if (this.context != null && this.context.variable() != null) {
-      variables.add(this.context.variable());
-    }
     variables.addAll(this.variables);
     return variables;
   }
@@ -140,7 +137,7 @@ public class ContentBlock {
   }
 
   public Set<String> getTemplateParameters() {
-    return this.getAllVariables().stream().map(v -> v.name).collect(Collectors.toSet());
+    return this.getAllVariables().stream().map(v -> v.name).collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   public Markup renderContent(MarkupGenerator markupGenerator) {

--- a/src/main/java/eu/europa/ted/efx/sdk2/EfxTemplateTranslatorV2.java
+++ b/src/main/java/eu/europa/ted/efx/sdk2/EfxTemplateTranslatorV2.java
@@ -629,6 +629,11 @@ public class EfxTemplateTranslatorV2 extends EfxExpressionTranslatorV2
         String fieldId = getFieldIdFromChildSimpleFieldReferenceContext(ctx);
         if (fieldId != null) {
           Variable contextVariable = this.getContextVariable(ctx, contextPath);
+          if (contextVariable != null) {
+            VariableList variables = this.stack.pop(VariableList.class);
+            variables.add(contextVariable);
+            this.stack.push(variables);
+          }
           this.exitFieldContextDeclaration(fieldId, contextPath, contextVariable);
         } else {
           String nodeId = getNodeIdFromChildSimpleNodeReferenceContext(ctx);
@@ -694,11 +699,6 @@ public class EfxTemplateTranslatorV2 extends EfxExpressionTranslatorV2
 
   }
 
-  @Override
-  public void enterTemplateVariableList(TemplateVariableListContext ctx) {
-    this.stack.push(new VariableList());
-  }
-
   // #region Variable Initializers --------------------------------------------
 
   @Override
@@ -740,7 +740,7 @@ public class EfxTemplateTranslatorV2 extends EfxExpressionTranslatorV2
           this.script.composeVariableDeclaration(variableName, expression.getClass()),
           expression,
           this.script.composeVariableReference(variableName, expression.getClass()));
-      variables.push(variable);
+      variables.add(variable);
       this.stack.push(variables);
       this.stack.declareIdentifier(variable);
     } catch (Exception e) {
@@ -752,18 +752,12 @@ public class EfxTemplateTranslatorV2 extends EfxExpressionTranslatorV2
 
   // #endregion New in EFX-2 --------------------------------------------------
 
-  /**
-   * This method changes the current EFX context.
-   * 
-   * The EFX context is always assumed to be either a Field or a Node. Any predicate included in the
-   * EFX context declaration is not relevant and is ignored.
-   */
   @Override
-  public void exitContextDeclarationBlock(ContextDeclarationBlockContext ctx) {
-    if (ctx.templateVariableList() == null) {
-      this.stack.push(new VariableList());
-    }
+  public void enterContextDeclarationBlock(ContextDeclarationBlockContext arg0) {
+    this.stack.push(new VariableList());
   }
+
+
 
 
   // #endregion Context Declaration Blocks {...} ------------------------------

--- a/src/test/java/eu/europa/ted/efx/sdk2/EfxTemplateTranslatorV2Test.java
+++ b/src/test/java/eu/europa/ted/efx/sdk2/EfxTemplateTranslatorV2Test.java
@@ -176,15 +176,15 @@ class EfxTemplateTranslatorV2Test extends EfxTestsBase {
   @Test
   void testTemplateLine_ContextVariable() {
     assertEquals(
-        lines("let block01(t, ctx) -> { #1: eval(for $x in ./normalize-space(text()) return concat($x, $t))", //
+        lines("let block01(ctx, t) -> { #1: eval(for $x in ./normalize-space(text()) return concat($x, $t))", //
             "for-each(.).call(block0101(ctx:$ctx, t:$t, t2:'test'))", //
             "for-each(.).call(block0102(ctx:$ctx, t:$t, t2:'test3')) }", //
-            "let block0101(t, ctx, t2) -> { #1.1: eval(for $y in ./normalize-space(text()) return concat($y, $t, $t2))", //
+            "let block0101(ctx, t, t2) -> { #1.1: eval(for $y in ./normalize-space(text()) return concat($y, $t, $t2))", //
             "for-each(.).call(block010101(ctx:$ctx, t:$t, t2:$t2))", //
             "for-each(.).call(block010102(ctx:$ctx, t:$t, t2:$t2)) }", //
-            "let block010101(t, ctx, t2) -> { eval(for $z in ./normalize-space(text()) return concat($z, $t, $ctx)) }", //
-            "let block010102(t, ctx, t2) -> { eval(for $z in ./normalize-space(text()) return concat($z, $t, $ctx)) }", //
-            "let block0102(t, ctx, t2) -> { eval(for $z in ./normalize-space(text()) return concat($z, $t2, $ctx)) }", //
+            "let block010101(ctx, t, t2) -> { eval(for $z in ./normalize-space(text()) return concat($z, $t, $ctx)) }", //
+            "let block010102(ctx, t, t2) -> { eval(for $z in ./normalize-space(text()) return concat($z, $t, $ctx)) }", //
+            "let block0102(ctx, t, t2) -> { eval(for $z in ./normalize-space(text()) return concat($z, $t2, $ctx)) }", //
             "for-each(/*/PathNode/TextField).call(block01(ctx:., t:./normalize-space(text())))"), //
         translateTemplate(lines(
             "{context:$ctx = BT-00-Text, text:$t = BT-00-Text} ${for text:$x in BT-00-Text return concat($x, $t)}",


### PR DESCRIPTION
TEDEFO-3343 is a bug about EFXT context variables being rendered in the XSL output in the reverse order from which they were declared.