### PR TITLE
pom: Update dependencies on logback 1.5.6 and slf4j 2.0.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,11 +64,11 @@
     <!-- Versions - Third-party libraries -->
     <version.antlr4>4.13.1</version.antlr4>
     <version.commons-lang3>3.12.0</version.commons-lang3>
-    <version.logback>1.2.11</version.logback>
+    <version.logback>1.5.6</version.logback>
     <version.jackson>2.13.4</version.jackson>
     <version.jackson-databind>2.13.4.2</version.jackson-databind>
     <version.junit-jupiter>5.7.2</version.junit-jupiter>
-    <version.slf4j>1.7.36</version.slf4j>
+    <version.slf4j>2.0.13</version.slf4j>
 
     <!-- Versions - Plugins -->
     <version.build-helper.plugin>3.3.0</version.build-helper.plugin>


### PR DESCRIPTION
This brings the fix for a vulnerability (CVE-2023-6378).