### PR TITLE
Add dictionary handling features to Markup and Script generators

### DIFF
--- a/src/main/java/eu/europa/ted/efx/interfaces/MarkupGenerator.java
+++ b/src/main/java/eu/europa/ted/efx/interfaces/MarkupGenerator.java
@@ -81,7 +81,7 @@ public interface MarkupGenerator {
     Markup renderVariableDeclaration(final Class<? extends EfxDataType> type, final String name, final Expression initialiser);
 
     /**
-     * Renders the markup necessary to declare a and initialise a dictionary .
+     * Renders the markup necessary to declare and initialise a dictionary .
      *
      * @param name  The name of the dictionary to be declared.
      * @param match The path expression to be indexed.

--- a/src/main/java/eu/europa/ted/efx/interfaces/MarkupGenerator.java
+++ b/src/main/java/eu/europa/ted/efx/interfaces/MarkupGenerator.java
@@ -81,6 +81,20 @@ public interface MarkupGenerator {
     Markup renderVariableDeclaration(final Class<? extends EfxDataType> type, final String name, final Expression initialiser);
 
     /**
+     * Renders the markup necessary to declare a and initialise a dictionary .
+     *
+     * @param name  The name of the dictionary to be declared.
+     * @param match The path expression to be indexed.
+     *              Each of the values matched by this path will be added
+     *              to the dictionary with the corresponding key.
+     * @param key   The expression to calculate the keys. To initialise the
+     *              dictionary the key needs to be calculated relative to
+     *              the match.
+     * @return A {@link Markup} object that declares the dictionary.
+     */
+    Markup renderDictionaryDeclaration(final String name, final PathExpression match, final StringExpression key);
+
+    /**
      * Renders the Markup necessary to make the function available at runtime.
      *
      * @param type       A sub-class of EfxDataType that represents the return type

--- a/src/main/java/eu/europa/ted/efx/interfaces/ScriptGenerator.java
+++ b/src/main/java/eu/europa/ted/efx/interfaces/ScriptGenerator.java
@@ -116,6 +116,8 @@ public interface ScriptGenerator {
 
   public <T extends TypedExpression> T composeParameterDeclaration(String parameterName, Class<T> type);
 
+  public <T extends TypedExpression> T composeDictionaryLookup(String dictionaryName, StringExpression keyExpression, Class<T> type);
+
   /**
    * Takes a list of expressions and returns the target language script that corresponds to a
    * list of expressions.

--- a/src/main/java/eu/europa/ted/efx/model/CallStack.java
+++ b/src/main/java/eu/europa/ted/efx/model/CallStack.java
@@ -14,6 +14,7 @@ import eu.europa.ted.efx.exceptions.TypeMismatchException;
 import eu.europa.ted.efx.model.expressions.TypedExpression;
 import eu.europa.ted.efx.model.types.EfxDataType;
 import eu.europa.ted.efx.model.variables.ParsedParameter;
+import eu.europa.ted.efx.model.variables.Dictionary;
 import eu.europa.ted.efx.model.variables.Function;
 import eu.europa.ted.efx.model.variables.Identifier;
 import eu.europa.ted.efx.model.variables.Identifiers;
@@ -275,11 +276,11 @@ public class CallStack {
   }
 
   /**
-   * Retrieves a function from the function registry by its name.
+   * Retrieves a function from the global identifier registry by its name.
    *
    * @param functionName the name of the function to retrieve
    * @return the {@link Function} associated with the given name
-   * @throws ParseCancellationException if the function name is not found in the registry,
+   * @throws InvalidIdentifierException if the function name is not found in the registry,
    *         with a message indicating the undeclared identifier
    */
   public Function getFunction(String functionName) {
@@ -289,11 +290,34 @@ public class CallStack {
         .orElseThrow(() -> InvalidIdentifierException.undeclaredIdentifier(functionName));
   }
 
+  /**
+   * Retrieves a template from the global identifier registry by its name.
+   *
+   * @param templateName the name of the template to retrieve
+   * @return the {@link Template} associated with the given name
+   * @throws InvalidIdentifierException if the template name is not found in the registry,
+   *         with a message indicating the undeclared identifier
+   */
   public Template getTemplate(String templateName) {
     return Optional.ofNullable(this.globalIdentifierRegistry.get(templateName))
         .filter(Template.class::isInstance)
         .map(Template.class::cast)
         .orElseThrow(() -> InvalidIdentifierException.undeclaredIdentifier(templateName));
+  }
+
+  /**
+   * Retrieves a dictionary from the global identifier registry by its name.
+   *
+   * @param dictionaryName the name of the dictionary to retrieve
+   * @return the {@link Dictionary} associated with the given name
+   * @throws InvalidIdentifierException if the dictionary name is not found in the registry,
+   *         with a message indicating the undeclared identifier
+   */
+  public Dictionary getDictionary(String dictionaryName) {
+    return Optional.ofNullable(this.globalIdentifierRegistry.get(dictionaryName))
+        .filter(Dictionary.class::isInstance)
+        .map(Dictionary.class::cast)
+        .orElseThrow(() -> InvalidIdentifierException.undeclaredIdentifier(dictionaryName));
   }
 
   /**

--- a/src/main/java/eu/europa/ted/efx/model/variables/Dictionary.java
+++ b/src/main/java/eu/europa/ted/efx/model/variables/Dictionary.java
@@ -23,13 +23,17 @@ public class Dictionary extends Identifier {
     if (o == null || getClass() != o.getClass()) return false;
     if (!super.equals(o)) return false;
     Dictionary dictionary = (Dictionary) o;
-    return java.util.Objects.equals(keyExpression, dictionary.keyExpression);
+    return java.util.Objects.equals(keyExpression, dictionary.keyExpression)
+        && java.util.Objects.equals(pathExpression, dictionary.pathExpression)
+        && java.util.Objects.equals(type, dictionary.type);
   }
 
   @Override
   public int hashCode() {
     int result = super.hashCode();
-    result = 31 * result + java.util.Objects.hashCode(keyExpression);
+    result = 31 * result + (keyExpression != null ? keyExpression.hashCode() : 0);
+    result = 31 * result + (pathExpression != null ? pathExpression.hashCode() : 0);
+    result = 31 * result + (type != null ? type.hashCode() : 0);
     return result;
   }
 }

--- a/src/main/java/eu/europa/ted/efx/model/variables/Dictionary.java
+++ b/src/main/java/eu/europa/ted/efx/model/variables/Dictionary.java
@@ -1,0 +1,35 @@
+package eu.europa.ted.efx.model.variables;
+
+import eu.europa.ted.efx.model.expressions.TypedExpression;
+import eu.europa.ted.efx.model.expressions.path.PathExpression;
+import eu.europa.ted.efx.model.expressions.scalar.StringExpression;
+
+public class Dictionary extends Identifier {
+  public final StringExpression keyExpression;
+  public final PathExpression pathExpression;
+  public final Class<? extends TypedExpression> type;
+
+  public Dictionary(String dictionaryName, PathExpression pathExpression, StringExpression keyExpression) {
+    
+    super(dictionaryName, keyExpression.getDataType());
+    this.keyExpression = keyExpression;
+    this.pathExpression = pathExpression;
+    this.type = pathExpression.getClass();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (!super.equals(o)) return false;
+    Dictionary dictionary = (Dictionary) o;
+    return java.util.Objects.equals(keyExpression, dictionary.keyExpression);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + java.util.Objects.hashCode(keyExpression);
+    return result;
+  }
+}

--- a/src/main/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2.java
+++ b/src/main/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2.java
@@ -1489,6 +1489,16 @@ public class EfxExpressionTranslatorV2 extends EfxBaseListener
     this.stack.push(this.script.getTextInPreferredLanguage(this.stack.pop(MultilingualStringPathExpression.class)));
   }
 
+  @Override
+  public void exitDictionaryLookup(DictionaryLookupContext ctx) {
+
+    var dictionary = this.stack.getDictionary(ctx.dictionaryName.getText());
+    this.stack.push(this.script.composeDictionaryLookup(
+        dictionary.name, this.stack.pop(StringExpression.class),
+        dictionary.type));
+
+  }
+
   // #endregion New in EFX-2 --------------------------------------------------
 
   // #endregion String functions ----------------------------------------------
@@ -1868,6 +1878,21 @@ public class EfxExpressionTranslatorV2 extends EfxBaseListener
       if (variableType != null) {
         // Insert the type cast
         this.rewriter.insertBefore(ctx.VariablePrefix().getSymbol(), "(" + variableType + ")");
+      }
+    }
+
+    @Override
+    public void exitDictionaryLookup(DictionaryLookupContext ctx) {
+      if (!hasParentContextOfType(ctx, LateBoundScalarContext.class)) {
+        return;
+      }
+
+      String dictionaryName = ctx.dictionaryName.getText();
+      String dictionaryType = javaToEfxTypeMap.get(this.stack.getTypeOfIdentifier(dictionaryName));
+
+      if (dictionaryType != null) {
+        // Insert the type cast
+        this.rewriter.insertBefore(ctx.VariablePrefix().getSymbol(), "(" + dictionaryType + ")");
       }
     }
 

--- a/src/main/java/eu/europa/ted/efx/sdk2/EfxTemplateTranslatorV2.java
+++ b/src/main/java/eu/europa/ted/efx/sdk2/EfxTemplateTranslatorV2.java
@@ -55,6 +55,7 @@ import eu.europa.ted.efx.model.templates.TemplateInvocation;
 import eu.europa.ted.efx.model.templates.Markup;
 import eu.europa.ted.efx.model.types.EfxDataType;
 import eu.europa.ted.efx.model.types.FieldTypes;
+import eu.europa.ted.efx.model.variables.Dictionary;
 import eu.europa.ted.efx.model.variables.Function;
 import eu.europa.ted.efx.model.variables.StrictArguments;
 import eu.europa.ted.efx.model.variables.Identifier;
@@ -76,6 +77,7 @@ import eu.europa.ted.efx.sdk2.EfxParser.ContextVariableInitializerContext;
 import eu.europa.ted.efx.sdk2.EfxParser.DateFunctionDeclarationContext;
 import eu.europa.ted.efx.sdk2.EfxParser.DateParameterDeclarationContext;
 import eu.europa.ted.efx.sdk2.EfxParser.DateVariableInitializerContext;
+import eu.europa.ted.efx.sdk2.EfxParser.DictionaryDeclarationContext;
 import eu.europa.ted.efx.sdk2.EfxParser.DurationFunctionDeclarationContext;
 import eu.europa.ted.efx.sdk2.EfxParser.DurationParameterDeclarationContext;
 import eu.europa.ted.efx.sdk2.EfxParser.DurationVariableInitializerContext;
@@ -358,6 +360,9 @@ public class EfxTemplateTranslatorV2 extends EfxExpressionTranslatorV2
       } else if (identifier instanceof Function) {
         Function function = (Function) identifier;
         globals.add(this.markup.renderFunctionDeclaration(function.dataType, function.name, function.parameters.toMap(), function.expression));
+      } else if (identifier instanceof Dictionary) {
+        Dictionary dictionary = (Dictionary) identifier;
+        globals.add(this.markup.renderDictionaryDeclaration(dictionary.name, dictionary.pathExpression, dictionary.keyExpression));
       }
     }
 
@@ -669,6 +674,16 @@ public class EfxTemplateTranslatorV2 extends EfxExpressionTranslatorV2
     NumericExpression quantity = ctx.pluraliser() != null ? this.stack.pop(NumericExpression.class) : NumericExpression.empty();
     StringExpression expression = this.stack.pop(StringExpression.class);
     this.stack.push(this.markup.renderLabelFromExpression(expression, quantity));
+  }
+
+  @Override
+  public void exitDictionaryDeclaration(DictionaryDeclarationContext ctx) {
+    String name = ctx.dictionaryName.getText();
+    StringExpression key = this.stack.pop(StringExpression.class);
+    var match = this.stack.pop(PathExpression.class);
+
+    // Declare the dictionary in the script
+    this.stack.declareGlobalIdentifier(new Dictionary(name, match, key));
   }
 
   // #endregion New in EFX-2 --------------------------------------------------
@@ -1271,6 +1286,13 @@ public class EfxTemplateTranslatorV2 extends EfxExpressionTranslatorV2
 
     // #endregion Scope management --------------------------------------------
 
+    @Override
+    public void exitDictionaryDeclaration(DictionaryDeclarationContext ctx) {
+      var dictionaryName = ctx.dictionaryName.getText();
+      var fieldId = getFieldIdFromChildSimpleFieldReferenceContext(ctx.fieldContext());
+      var field = this.symbols.getAbsolutePathOfField(fieldId);
+      this.stack.declareGlobalIdentifier(new Dictionary(dictionaryName, field, StringExpression.empty()));
+    }
   }
 
   // #endregion Pre-processing ------------------------------------------------

--- a/src/main/java/eu/europa/ted/efx/xpath/XPathScriptGenerator.java
+++ b/src/main/java/eu/europa/ted/efx/xpath/XPathScriptGenerator.java
@@ -140,6 +140,13 @@ public class XPathScriptGenerator implements ScriptGenerator {
   }
 
   @Override
+  public <T extends TypedExpression> T composeDictionaryLookup(String dictionaryName, StringExpression keyExpression,
+      Class<T> type) {
+        return Expression.instantiate(
+            String.format("key(%s, %s)", quoted(dictionaryName), keyExpression.getScript()), type);
+  }
+
+  @Override
   public <T extends SequenceExpression> T composeList(List<? extends ScalarExpression> list,
       Class<T> type) {
     if (list == null || list.isEmpty()) {

--- a/src/test/java/eu/europa/ted/efx/mock/MarkupGeneratorMock.java
+++ b/src/test/java/eu/europa/ted/efx/mock/MarkupGeneratorMock.java
@@ -172,7 +172,7 @@ public class MarkupGeneratorMock implements MarkupGenerator {
   @Override
   public Markup renderDictionaryDeclaration(final String name, final PathExpression match,
       final StringExpression key) {
-        return new Markup(String.format("let %s index %s by %s;)", name, match.getScript(), key.getScript()));
+        return new Markup(String.format("let %s index %s by %s;", name, match.getScript(), key.getScript()));
   }
 
 }

--- a/src/test/java/eu/europa/ted/efx/mock/MarkupGeneratorMock.java
+++ b/src/test/java/eu/europa/ted/efx/mock/MarkupGeneratorMock.java
@@ -168,4 +168,11 @@ public class MarkupGeneratorMock implements MarkupGenerator {
   public Markup getEfxDataTypeEquivalent(Class<? extends EfxDataType> type) {
     return typeFromEfxDataType.getOrDefault(type, Markup.empty());
   }
+
+  @Override
+  public Markup renderDictionaryDeclaration(final String name, final PathExpression match,
+      final StringExpression key) {
+        return new Markup(String.format("let %s index %s by %s;)", name, match.getScript(), key.getScript()));
+  }
+
 }

--- a/src/test/java/eu/europa/ted/efx/sdk2/EfxTemplateTranslatorV2Test.java
+++ b/src/test/java/eu/europa/ted/efx/sdk2/EfxTemplateTranslatorV2Test.java
@@ -345,7 +345,7 @@ class EfxTemplateTranslatorV2Test extends EfxTestsBase {
   void testGlobals_DictionaryDeclaration() {
     assertEquals(
         lines(
-            "let dic index /*/PathNode/NumberField by /*/PathNode/TextField/normalize-space(text());)",
+            "let dic index /*/PathNode/NumberField by /*/PathNode/TextField/normalize-space(text());",
             "let block01() -> { eval(key('dic', 'key')) }",
             "for-each(/*).call(block01())"),
         translateTemplate(lines(

--- a/src/test/java/eu/europa/ted/efx/sdk2/EfxTemplateTranslatorV2Test.java
+++ b/src/test/java/eu/europa/ted/efx/sdk2/EfxTemplateTranslatorV2Test.java
@@ -341,6 +341,18 @@ class EfxTemplateTranslatorV2Test extends EfxTestsBase {
             "let text:$t4= ?test($t3, 22);")));
   }
 
+  @Test
+  void testGlobals_DictionaryDeclaration() {
+    assertEquals(
+        lines(
+            "let dic index /*/PathNode/NumberField by /*/PathNode/TextField/normalize-space(text());)",
+            "let block01() -> { eval(key('dic', 'key')) }",
+            "for-each(/*).call(block01())"),
+        translateTemplate(lines(
+            "let $dic index BT-00-Number by BT-00-Text;",
+            "display ${$dic['key']};")));
+  }
+
   // #endregion Globals -------------------------------------------------------
 
   @Test


### PR DESCRIPTION
- Introduced renderDictionaryDeclaration method in MarkupGenerator.
- Added composeDictionaryLookup method in ScriptGenerator and XPathScriptGenerator.
- Implemented getDictionary method in CallStack to retrieve dictionaries.
- Created Dictionary class to encapsulate dictionary properties.
- Enhanced EfxTemplateTranslatorV2 to support dictionary declarations and lookups.
- Updated tests to validate dictionary declaration and usage.