### PR TITLE
Fix vulnerable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
     <version.antlr4>4.13.1</version.antlr4>
     <version.commons-lang3>3.12.0</version.commons-lang3>
     <version.logback>1.5.6</version.logback>
-    <version.jackson>2.13.4</version.jackson>
-    <version.jackson-databind>2.13.4.2</version.jackson-databind>
+    <version.jackson>2.18.3</version.jackson>
+    <version.jackson-databind>2.18.3</version.jackson-databind>
     <version.junit-jupiter>5.7.2</version.junit-jupiter>
     <version.slf4j>2.0.13</version.slf4j>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 
     <!-- Versions - Third-party libraries -->
     <version.antlr4>4.13.1</version.antlr4>
-    <version.commons-lang3>3.12.0</version.commons-lang3>
+    <version.commons-lang3>3.18.0</version.commons-lang3>
     <version.logback>1.5.6</version.logback>
     <version.jackson>2.18.3</version.jackson>
     <version.jackson-databind>2.18.3</version.jackson-databind>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <!-- Versions - Third-party libraries -->
     <version.antlr4>4.13.1</version.antlr4>
     <version.commons-lang3>3.18.0</version.commons-lang3>
-    <version.logback>1.5.6</version.logback>
+    <version.logback>1.5.18</version.logback>
     <version.jackson>2.18.3</version.jackson>
     <version.jackson-databind>2.18.3</version.jackson-databind>
     <version.junit-jupiter>5.7.2</version.junit-jupiter>


### PR DESCRIPTION
This adresses the 2 alerts currently at https://github.com/OP-TED/efx-toolkit-java/security/dependabot, and also one vulnerability in logback that should probably have been also reported there.