### PR TITLE
TEDEFO-4932 Fix type mismatch on property accessors of repeatable fields from own context

### DIFF
--- a/src/main/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2.java
+++ b/src/main/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2.java
@@ -1945,6 +1945,11 @@ public class EfxExpressionTranslatorV2 extends EfxBaseListener
   }
 
   private boolean isFieldRepeatableFromContext(String fieldId, Context context) {
+    // Skip repeatability check if context IS this field (e.g., inside a WITH block on this field).
+    // In that case, we're referencing the current element being iterated, not the whole sequence.
+    if (context.isFieldContext() && fieldId.equals(context.symbol())) {
+      return false;
+    }
     String contextNodeId = context.isFieldContext()
         ? this.symbols.getParentNodeOfField(context.symbol())
         : context.symbol();

--- a/src/main/java/eu/europa/ted/efx/xpath/XPathScriptGenerator.java
+++ b/src/main/java/eu/europa/ted/efx/xpath/XPathScriptGenerator.java
@@ -128,7 +128,7 @@ public class XPathScriptGenerator implements ScriptGenerator {
 
   @Override
   public StringExpression composeFieldRawValueReference(PathExpression fieldReference) {
-    return new StringExpression(fieldReference.getScript() + "/normalize-space(text())");
+    return new StringExpression(fieldReference.getScript() + "/text()");
   }
 
   @Override

--- a/src/test/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2Test.java
+++ b/src/test/java/eu/europa/ted/efx/sdk2/EfxExpressionTranslatorV2Test.java
@@ -1506,6 +1506,55 @@ class EfxExpressionTranslatorV2Test extends EfxTestsBase {
   }
 
   @Test
+  void testComputedProperty_wasWithheld_repeatableFieldFromOwnContext() {
+    testExpressionTranslationWithContext(
+        "../FieldsPrivacy[FieldIdentifierCode/text()='rep-text-priv']/FieldIdentifierCode/normalize-space(text()) = 'rep-text-priv'",
+        "BT-00-Repeatable-Text",
+        "BT-00-Repeatable-Text:wasWithheld");
+  }
+
+  @Test
+  void testComputedProperty_isWithheld_repeatableFieldFromOwnContext() {
+    final String privacyPath = "../FieldsPrivacy[FieldIdentifierCode/text()='rep-text-priv']";
+    testExpressionTranslationWithContext(
+        privacyPath + "/FieldIdentifierCode/normalize-space(text()) = 'rep-text-priv'"
+            + " and "
+            + "(not(" + privacyPath + "/PublicationDate)"
+            + " or "
+            + privacyPath + "/PublicationDate/xs:date(text()) > current-date())",
+        "BT-00-Repeatable-Text",
+        "BT-00-Repeatable-Text:isWithheld");
+  }
+
+  @Test
+  void testComputedProperty_isDisclosed_repeatableFieldFromOwnContext() {
+    final String privacyPath = "../FieldsPrivacy[FieldIdentifierCode/text()='rep-text-priv']";
+    testExpressionTranslationWithContext(
+        privacyPath + "/FieldIdentifierCode/normalize-space(text()) = 'rep-text-priv'"
+            + " and "
+            + "not("
+                + "(not(" + privacyPath + "/PublicationDate)"
+                + " or "
+                + privacyPath + "/PublicationDate/xs:date(text()) > current-date())"
+            + ")"
+            + " and "
+            + "not(./normalize-space(text()) = 'unpublished')",
+        "BT-00-Repeatable-Text",
+        "BT-00-Repeatable-Text:isDisclosed");
+  }
+
+  @Test
+  void testComputedProperty_isMasked_repeatableFieldFromOwnContext() {
+    final String privacyPath = "../FieldsPrivacy[FieldIdentifierCode/text()='rep-text-priv']";
+    testExpressionTranslationWithContext(
+        privacyPath + "/FieldIdentifierCode/normalize-space(text()) = 'rep-text-priv'"
+            + " and "
+            + "./normalize-space(text()) = 'unpublished'",
+        "BT-00-Repeatable-Text",
+        "BT-00-Repeatable-Text:isMasked");
+  }
+
+  @Test
   void testComputedProperty_isDisclosed_numericField() {
     final String privacyPath = "../FieldsPrivacy[FieldIdentifierCode/text()='num-priv']";
     testExpressionTranslationWithContext(
@@ -1573,7 +1622,7 @@ class EfxExpressionTranslatorV2Test extends EfxTestsBase {
   @Test
   void testFieldRawValue_Duration() {
     testExpressionTranslationWithContext(
-        "PathNode/DurationField/normalize-space(text())",
+        "PathNode/DurationField/text()",
         "ND-Root",
         "BT-00-Duration:rawValue");
   }
@@ -1581,7 +1630,7 @@ class EfxExpressionTranslatorV2Test extends EfxTestsBase {
   @Test
   void testFieldRawValue_Text() {
     testExpressionTranslationWithContext(
-        "PathNode/TextField/normalize-space(text())",
+        "PathNode/TextField/text()",
         "ND-Root",
         "BT-00-Text:rawValue");
   }
@@ -1589,9 +1638,17 @@ class EfxExpressionTranslatorV2Test extends EfxTestsBase {
   @Test
   void testFieldRawValue_Number() {
     testExpressionTranslationWithContext(
-        "PathNode/NumberField/normalize-space(text())",
+        "PathNode/NumberField/text()",
         "ND-Root",
         "BT-00-Number:rawValue");
+  }
+
+  @Test
+  void testFieldRawValue_RepeatableFieldFromOwnContext() {
+    testExpressionTranslationWithContext(
+        "./text()",
+        "BT-00-Repeatable-Text",
+        "BT-00-Repeatable-Text:rawValue");
   }
 
   // #endregion: Boolean functions
@@ -1631,7 +1688,7 @@ class EfxExpressionTranslatorV2Test extends EfxTestsBase {
   @Test
   void testNumberFromDurationField_ExplicitRawValue() {
     testExpressionTranslationWithContext(
-        "number(PathNode/DurationField/normalize-space(text()))",
+        "number(PathNode/DurationField/text())",
         "ND-Root",
         "number(BT-00-Duration:rawValue)");
   }
@@ -1639,7 +1696,7 @@ class EfxExpressionTranslatorV2Test extends EfxTestsBase {
   @Test
   void testFieldRawValue_NumberLikePattern() {
     testExpressionTranslationWithContext(
-        "fn:matches(normalize-space(PathNode/NumberField/normalize-space(text())), '[0-9]+\\.[0-9]+')",
+        "fn:matches(normalize-space(PathNode/NumberField/text()), '[0-9]+\\.[0-9]+')",
         "ND-Root",
         "BT-00-Number:rawValue like '[0-9]+\\.[0-9]+'");
   }
@@ -1647,7 +1704,7 @@ class EfxExpressionTranslatorV2Test extends EfxTestsBase {
   @Test
   void testNumberFromDurationRawValue_Comparison() {
     testExpressionTranslationWithContext(
-        "number(PathNode/DurationField/normalize-space(text())) > 3",
+        "number(PathNode/DurationField/text()) > 3",
         "ND-Root",
         "number(BT-00-Duration:rawValue) > 3");
   }

--- a/src/test/resources/json/sdk2-fields.json
+++ b/src/test/resources/json/sdk2-fields.json
@@ -97,6 +97,13 @@
       "alias": "RepeatableInRepeatableNode2"
     },
     {
+      "id": "ND-PrivacyForRepeatableText",
+      "parentId": "ND-Root",
+      "xpathAbsolute": "/*/PathNode/FieldsPrivacy[FieldIdentifierCode/text()='rep-text-priv']",
+      "xpathRelative": "PathNode/FieldsPrivacy[FieldIdentifierCode/text()='rep-text-priv']",
+      "repeatable": false
+    },
+    {
       "id": "ND-PrivacyInRepeatableNode",
       "parentId": "ND-RepeatableNode",
       "xpathAbsolute": "/*/RepeatableNode/FieldsPrivacy[FieldIdentifierCode/text()='test-priv']",
@@ -350,6 +357,13 @@
       "xpathRelative": "PathNode/RepeatableTextField",
       "repeatable": {
         "value": true
+      },
+      "privacy": {
+        "code": "rep-text-priv",
+        "unpublishedFieldId": "BT-195(BT-00)-Repeatable-Text",
+        "reasonCodeFieldId": "BT-197(BT-00)-Repeatable-Text",
+        "reasonDescriptionFieldId": "BT-196(BT-00)-Repeatable-Text",
+        "publicationDateFieldId": "BT-198(BT-00)-Repeatable-Text"
       }
     },
     {
@@ -1041,6 +1055,35 @@
       "type": "date",
       "parentNodeId": "ND-PrivacyInRepeatableNode",
       "xpathAbsolute": "/*/RepeatableNode/FieldsPrivacy[FieldIdentifierCode/text()='test-priv']/PublicationDate",
+      "xpathRelative": "PublicationDate"
+    },
+    {
+      "id": "BT-195(BT-00)-Repeatable-Text",
+      "type": "code",
+      "parentNodeId": "ND-PrivacyForRepeatableText",
+      "xpathAbsolute": "/*/PathNode/FieldsPrivacy[FieldIdentifierCode/text()='rep-text-priv']/FieldIdentifierCode",
+      "xpathRelative": "FieldIdentifierCode",
+      "presetValue": "rep-text-priv"
+    },
+    {
+      "id": "BT-196(BT-00)-Repeatable-Text",
+      "type": "text-multilingual",
+      "parentNodeId": "ND-PrivacyForRepeatableText",
+      "xpathAbsolute": "/*/PathNode/FieldsPrivacy[FieldIdentifierCode/text()='rep-text-priv']/ReasonDescription",
+      "xpathRelative": "ReasonDescription"
+    },
+    {
+      "id": "BT-197(BT-00)-Repeatable-Text",
+      "type": "code",
+      "parentNodeId": "ND-PrivacyForRepeatableText",
+      "xpathAbsolute": "/*/PathNode/FieldsPrivacy[FieldIdentifierCode/text()='rep-text-priv']/ReasonCode",
+      "xpathRelative": "ReasonCode"
+    },
+    {
+      "id": "BT-198(BT-00)-Repeatable-Text",
+      "type": "date",
+      "parentNodeId": "ND-PrivacyForRepeatableText",
+      "xpathAbsolute": "/*/PathNode/FieldsPrivacy[FieldIdentifierCode/text()='rep-text-priv']/PublicationDate",
       "xpathRelative": "PublicationDate"
     }
   ]


### PR DESCRIPTION
Skip repeatability check when the field IS the context (e.g. inside a WITH block). Also make :rawValue return raw text() instead of normalize-space(text()).