### PR TITLE
schematron: Fix order of elements in top-level file (TEDEFO-4970)

### DIFF
--- a/src/main/resources/freemarker/schematron/complete-validation.ftl
+++ b/src/main/resources/freemarker/schematron/complete-validation.ftl
@@ -40,6 +40,11 @@
     </#list>
     </phase>
 </#list>
+
+    <#-- Includes for all pattern files -->
+<#list includes as include>
+    <include href="${include}"/>
+</#list>
 <#if diagnostics?has_content>
 
     <diagnostics>
@@ -48,10 +53,5 @@
     </#list>
     </diagnostics>
 </#if>
-
-    <#-- Includes for all pattern files -->
-<#list includes as include>
-    <include href="${include}"/>
-</#list>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testDiagnostics_NoDuplicateEntries/dynamic/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testDiagnostics_NoDuplicateEntries/dynamic/complete-validation.sch
@@ -24,11 +24,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testDiagnostics_NoDuplicateEntries/static/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testDiagnostics_NoDuplicateEntries/static/complete-validation.sch
@@ -24,11 +24,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testDiagnostics_SanitizesParentheses/dynamic/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testDiagnostics_SanitizesParentheses/dynamic/complete-validation.sch
@@ -24,11 +24,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-Root_BT-00_a_-Text" see="field:BT-00(a)-Text">PathNode/TextFieldA</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testDiagnostics_SanitizesParentheses/static/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testDiagnostics_SanitizesParentheses/static/complete-validation.sch
@@ -24,11 +24,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-Root_BT-00_a_-Text" see="field:BT-00(a)-Text">PathNode/TextFieldA</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testForClause_NodeReference/dynamic/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testForClause_NodeReference/dynamic/complete-validation.sch
@@ -24,11 +24,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="BT-00-Text_ND-SubNode" see="node:ND-SubNode">../../SubNode</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testForClause_NodeReference/static/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testForClause_NodeReference/static/complete-validation.sch
@@ -24,11 +24,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="BT-00-Text_ND-SubNode" see="node:ND-SubNode">../../SubNode</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testInClause_NoticeTypeRange/dynamic/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testInClause_NoticeTypeRange/dynamic/complete-validation.sch
@@ -36,15 +36,15 @@
         <active pattern="EFORMS-validation-stage-1a-E2" />
     </phase>
 
-    <diagnostics>
-        <diagnostic id="ND-SubNode_BT-00-Text" see="field:BT-00-Text">../PathNode/TextField</diagnostic>
-    </diagnostics>
-
     <include href="validation-stage-1a-5.sch"/>
     <include href="validation-stage-1a-9.sch"/>
     <include href="validation-stage-1a-10.sch"/>
     <include href="validation-stage-1a-11.sch"/>
     <include href="validation-stage-1a-E1.sch"/>
     <include href="validation-stage-1a-E2.sch"/>
+
+    <diagnostics>
+        <diagnostic id="ND-SubNode_BT-00-Text" see="field:BT-00-Text">../PathNode/TextField</diagnostic>
+    </diagnostics>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testInClause_NoticeTypeRange/static/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testInClause_NoticeTypeRange/static/complete-validation.sch
@@ -36,15 +36,15 @@
         <active pattern="EFORMS-validation-stage-1a-E2" />
     </phase>
 
-    <diagnostics>
-        <diagnostic id="ND-SubNode_BT-00-Text" see="field:BT-00-Text">../PathNode/TextField</diagnostic>
-    </diagnostics>
-
     <include href="validation-stage-1a-5.sch"/>
     <include href="validation-stage-1a-9.sch"/>
     <include href="validation-stage-1a-10.sch"/>
     <include href="validation-stage-1a-11.sch"/>
     <include href="validation-stage-1a-E1.sch"/>
     <include href="validation-stage-1a-E2.sch"/>
+
+    <diagnostics>
+        <diagnostic id="ND-SubNode_BT-00-Text" see="field:BT-00-Text">../PathNode/TextField</diagnostic>
+    </diagnostics>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testInClause_SpecificNoticeTypes/dynamic/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testInClause_SpecificNoticeTypes/dynamic/complete-validation.sch
@@ -27,12 +27,12 @@
         <active pattern="EFORMS-validation-stage-1a-3" />
     </phase>
 
-    <diagnostics>
-        <diagnostic id="ND-SubNode_BT-00-Text" see="field:BT-00-Text">../PathNode/TextField</diagnostic>
-    </diagnostics>
-
     <include href="validation-stage-1a-1.sch"/>
     <include href="validation-stage-1a-2.sch"/>
     <include href="validation-stage-1a-3.sch"/>
+
+    <diagnostics>
+        <diagnostic id="ND-SubNode_BT-00-Text" see="field:BT-00-Text">../PathNode/TextField</diagnostic>
+    </diagnostics>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testInClause_SpecificNoticeTypes/static/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testInClause_SpecificNoticeTypes/static/complete-validation.sch
@@ -27,12 +27,12 @@
         <active pattern="EFORMS-validation-stage-1a-3" />
     </phase>
 
-    <diagnostics>
-        <diagnostic id="ND-SubNode_BT-00-Text" see="field:BT-00-Text">../PathNode/TextField</diagnostic>
-    </diagnostics>
-
     <include href="validation-stage-1a-1.sch"/>
     <include href="validation-stage-1a-2.sch"/>
     <include href="validation-stage-1a-3.sch"/>
+
+    <diagnostics>
+        <diagnostic id="ND-SubNode_BT-00-Text" see="field:BT-00-Text">../PathNode/TextField</diagnostic>
+    </diagnostics>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testOutput_ComprehensiveMixedRules/dynamic/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testOutput_ComprehensiveMixedRules/dynamic/complete-validation.sch
@@ -26,6 +26,11 @@
         <active pattern="EFORMS-validation-stage-2a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+    <include href="validation-stage-2a-1.sch"/>
+    <include href="validation-stage-2a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="BT-00-Text_BT-00-Number" see="field:BT-00-Number">../NumberField</diagnostic>
         <diagnostic id="BT-00-Text_BT-00-Indicator" see="field:BT-00-Indicator">../IndicatorField</diagnostic>
@@ -39,10 +44,5 @@
         <diagnostic id="ND-Root_BT-00-Number" see="field:BT-00-Number">PathNode/NumberField</diagnostic>
         <diagnostic id="ND-Root_BT-00-Indicator" see="field:BT-00-Indicator">PathNode/IndicatorField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
-    <include href="validation-stage-2a-1.sch"/>
-    <include href="validation-stage-2a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testOutput_ComprehensiveMixedRules/static/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testOutput_ComprehensiveMixedRules/static/complete-validation.sch
@@ -26,6 +26,11 @@
         <active pattern="EFORMS-validation-stage-2a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+    <include href="validation-stage-2a-1.sch"/>
+    <include href="validation-stage-2a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="BT-00-Text_BT-00-Number" see="field:BT-00-Number">../NumberField</diagnostic>
         <diagnostic id="BT-00-Text_BT-00-Indicator" see="field:BT-00-Indicator">../IndicatorField</diagnostic>
@@ -39,10 +44,5 @@
         <diagnostic id="ND-Root_BT-00-Number" see="field:BT-00-Number">PathNode/NumberField</diagnostic>
         <diagnostic id="ND-Root_BT-00-Indicator" see="field:BT-00-Indicator">PathNode/IndicatorField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
-    <include href="validation-stage-2a-1.sch"/>
-    <include href="validation-stage-2a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testOutput_FromSampleRulesFile/dynamic/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testOutput_FromSampleRulesFile/dynamic/complete-validation.sch
@@ -78,6 +78,13 @@
         <active pattern="EFORMS-validation-stage-3a" />
     </phase>
 
+    <include href="validation-stage-1a.sch"/>
+    <include href="validation-stage-1b-1.sch"/>
+    <include href="validation-stage-1b-2.sch"/>
+    <include href="validation-stage-1b-3.sch"/>
+    <include href="validation-stage-2a.sch"/>
+    <include href="validation-stage-3a.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
         <diagnostic id="ND-SubNode_BT-00-Text" see="field:BT-00-Text">../PathNode/TextField</diagnostic>
@@ -86,12 +93,5 @@
         <diagnostic id="ND-Root_BT-00-Indicator" see="field:BT-00-Indicator">PathNode/IndicatorField</diagnostic>
         <diagnostic id="ND-SubSubNode_BT-00-Indicator" see="field:BT-00-Indicator">../../PathNode/IndicatorField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a.sch"/>
-    <include href="validation-stage-1b-1.sch"/>
-    <include href="validation-stage-1b-2.sch"/>
-    <include href="validation-stage-1b-3.sch"/>
-    <include href="validation-stage-2a.sch"/>
-    <include href="validation-stage-3a.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testOutput_FromSampleRulesFile/static/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testOutput_FromSampleRulesFile/static/complete-validation.sch
@@ -78,6 +78,13 @@
         <active pattern="EFORMS-validation-stage-3a" />
     </phase>
 
+    <include href="validation-stage-1a.sch"/>
+    <include href="validation-stage-1b-1.sch"/>
+    <include href="validation-stage-1b-2.sch"/>
+    <include href="validation-stage-1b-3.sch"/>
+    <include href="validation-stage-2a.sch"/>
+    <include href="validation-stage-3a.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
         <diagnostic id="ND-SubNode_BT-00-Text" see="field:BT-00-Text">../PathNode/TextField</diagnostic>
@@ -86,12 +93,5 @@
         <diagnostic id="ND-Root_BT-00-Indicator" see="field:BT-00-Indicator">PathNode/IndicatorField</diagnostic>
         <diagnostic id="ND-SubSubNode_BT-00-Indicator" see="field:BT-00-Indicator">../../PathNode/IndicatorField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a.sch"/>
-    <include href="validation-stage-1b-1.sch"/>
-    <include href="validation-stage-1b-2.sch"/>
-    <include href="validation-stage-1b-3.sch"/>
-    <include href="validation-stage-2a.sch"/>
-    <include href="validation-stage-3a.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testStage_Multiple_GeneratesSeparatePatterns/dynamic/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testStage_Multiple_GeneratesSeparatePatterns/dynamic/complete-validation.sch
@@ -26,14 +26,14 @@
         <active pattern="EFORMS-validation-stage-1b-2" />
     </phase>
 
-    <diagnostics>
-        <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
-        <diagnostic id="ND-SubSubNode_BT-00-Text" see="field:BT-00-Text">../../PathNode/TextField</diagnostic>
-    </diagnostics>
-
     <include href="validation-stage-1a-1.sch"/>
     <include href="validation-stage-1a-2.sch"/>
     <include href="validation-stage-1b-1.sch"/>
     <include href="validation-stage-1b-2.sch"/>
+
+    <diagnostics>
+        <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
+        <diagnostic id="ND-SubSubNode_BT-00-Text" see="field:BT-00-Text">../../PathNode/TextField</diagnostic>
+    </diagnostics>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testStage_Multiple_GeneratesSeparatePatterns/static/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testStage_Multiple_GeneratesSeparatePatterns/static/complete-validation.sch
@@ -26,14 +26,14 @@
         <active pattern="EFORMS-validation-stage-1b-2" />
     </phase>
 
-    <diagnostics>
-        <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
-        <diagnostic id="ND-SubSubNode_BT-00-Text" see="field:BT-00-Text">../../PathNode/TextField</diagnostic>
-    </diagnostics>
-
     <include href="validation-stage-1a-1.sch"/>
     <include href="validation-stage-1a-2.sch"/>
     <include href="validation-stage-1b-1.sch"/>
     <include href="validation-stage-1b-2.sch"/>
+
+    <diagnostics>
+        <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
+        <diagnostic id="ND-SubSubNode_BT-00-Text" see="field:BT-00-Text">../../PathNode/TextField</diagnostic>
+    </diagnostics>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testVariable_Global_AppearsBeforeIncludes/dynamic/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testVariable_Global_AppearsBeforeIncludes/dynamic/complete-validation.sch
@@ -26,11 +26,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testVariable_Global_AppearsBeforeIncludes/static/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testVariable_Global_AppearsBeforeIncludes/static/complete-validation.sch
@@ -26,11 +26,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testWhen_SimpleCondition/dynamic/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testWhen_SimpleCondition/dynamic/complete-validation.sch
@@ -24,11 +24,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-SubNode_BT-00-Text" see="field:BT-00-Text">../PathNode/TextField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testWhen_SimpleCondition/static/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testWhen_SimpleCondition/static/complete-validation.sch
@@ -24,11 +24,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-SubNode_BT-00-Text" see="field:BT-00-Text">../PathNode/TextField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testWithClause_ContextVariableOverride/dynamic/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testWithClause_ContextVariableOverride/dynamic/complete-validation.sch
@@ -24,11 +24,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testWithClause_ContextVariableOverride/static/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testWithClause_ContextVariableOverride/static/complete-validation.sch
@@ -24,11 +24,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testWithClause_RootContextShortcut/dynamic/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testWithClause_RootContextShortcut/dynamic/complete-validation.sch
@@ -24,11 +24,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>

--- a/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testWithClause_RootContextShortcut/static/complete-validation.sch
+++ b/src/test/resources/eu/europa/ted/efx/sdk2/EfxRulesTranslatorV2Test/testWithClause_RootContextShortcut/static/complete-validation.sch
@@ -24,11 +24,11 @@
         <active pattern="EFORMS-validation-stage-1a-2" />
     </phase>
 
+    <include href="validation-stage-1a-1.sch"/>
+    <include href="validation-stage-1a-2.sch"/>
+
     <diagnostics>
         <diagnostic id="ND-Root_BT-00-Text" see="field:BT-00-Text">PathNode/TextField</diagnostic>
     </diagnostics>
-
-    <include href="validation-stage-1a-1.sch"/>
-    <include href="validation-stage-1a-2.sch"/>
 
 </schema>


### PR DESCRIPTION
The "pattern" elements must come before any "diagnostics" element. The "include" elements bring in "pattern" elements, so they must be before "diagnostics".