### PR TITLE
Publish when a release is published, not when it is created

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
       - 'main'
 
   release:
-    types: [created]
+    types: [published]
 
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
The publish workflow listens for `release: types: [created]`. That event does not fire when a release is saved as a draft and published later, so such a release has to be published by hand.

`published` fires in both cases: a release published directly, and a draft published afterwards.

`released` would be the wrong choice here — it does not fire for pre-releases, and this repository publishes alpha and beta versions as pre-releases.

Same change as [OP-TED/eforms-core-java#64](https://github.com/OP-TED/eforms-core-java/pull/64), where it has since been confirmed working: the 1.9.0 release triggered the workflow on its own.