### PR TITLE
Check the javadoc on every push

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,21 @@
+name: Check the javadoc
+
+on:
+  push:
+
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  javadoc:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Check javadoc
+        run: mvn --batch-mode clean test-compile javadoc:javadoc javadoc:test-javadoc


### PR DESCRIPTION
The javadoc is generated only by the `release` profile, which runs at `deploy` — on pushes to `develop` and when a release is published. A malformed comment therefore fails the publish, after the GitHub release is already tagged and public, leaving a release that points at nothing on Maven Central.

Maven Central itself does not inspect the javadoc: it requires a `-javadoc.jar` to be present and explicitly says it does not evaluate the contents, allowing even a placeholder jar. What fails is our own build, because `doclint` is set to `all,-missing` in the pom. That setting is worth keeping — it catches broken `{@link}`s and malformed HTML — so it should be checked where the comment is written rather than at publication.

A separate workflow rather than a step in `build.yml`, so the failing check names itself in the pull request. Tests are compiled but not run; `build.yml` is unchanged.

Both `javadoc:javadoc` and `javadoc:test-javadoc` pass on this branch today.