### PR TITLE
Publish a version once, when its release is published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'develop'
-      - 'main'
 
   release:
     types: [published]


### PR DESCRIPTION
The publish workflow deploys on a push to `main` as well as on a published release, so merging a release branch into `main` deploys the version, and publishing the GitHub release deploys the same coordinates again. With `autoPublish` set, the second attempt fails on a version that is already published.

This did not show until now because the `release` trigger listened for `created`, which does not fire when a release is saved as a draft and published later — so in practice only the push to `main` ever deployed. Now that the trigger is `published`, both fire.

Removing `main` from the push trigger leaves `develop` publishing snapshots and the release publishing versions, which is what the tag is for and how [eforms-core-java](https://github.com/OP-TED/eforms-core-java/blob/develop/.github/workflows/publish.yml) already works. The 1.9.0 release of that library published itself correctly this way.